### PR TITLE
ci(semantic-release): replace gemspec version on release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,13 @@ jobs:
     - git config --global user.email "releases@ladybug.tools"
     - git config --global user.name "ladybugbot"
     - npx semantic-release
-  - stage: docs
-    if: branch = master AND (NOT type IN (pull_request))
+  - stage: deploy
+    if: tag IS present
+    script:
+      - sed -i 's/FromHoneybee::VERSION/'"$TRAVIS_TAG"'/g' honeybee-openstudio.gemspec
     deploy:
+      on:
+        tags: true
       provider: rubygems
       skip_cleanup: true
       api_key: $API_KEY


### PR DESCRIPTION
The deploy job has a script that replaces the gemspec version by the new tag ($TRAVIS_TAG)

close #112