### PR TITLE
fix(rake): update rake dependency to 12.3.3

### DIFF
--- a/honeybee-openstudio.gemspec
+++ b/honeybee-openstudio.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'bundler', '~> 1.14'
-  spec.add_development_dependency 'rake', '12.3.1'
+  spec.add_development_dependency 'rake', '12.3.3'
   spec.add_development_dependency 'rspec', '3.7.0'
   spec.add_development_dependency 'rubocop', '~> 0.54.0'
 


### PR DESCRIPTION
Github opened a medium vulerability alert on the rake dependency so I upgraded it to the recomended version.

![image](https://user-images.githubusercontent.com/20436635/82991895-48c71800-9ff6-11ea-8556-d4a5c7491098.png)
