### PR TITLE
feat(openstudio): Upgrade to OpenStudio 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,16 @@
+dist: bionic
 language: ruby
 
 rvm:
-  - 2.2
+  - 2.5
 
 before_install:
 # install openstudio
-- wget http://security.ubuntu.com/ubuntu/pool/universe/w/wxwidgets3.0/libwxbase3.0-0_3.0.0-2_amd64.deb
-- sudo apt install ./libwxbase3.0-0_3.0.0-2_amd64.deb
-- wget http://security.ubuntu.com/ubuntu/pool/universe/w/wxwidgets3.0/libwxgtk3.0-0_3.0.0-2_amd64.deb
-- sudo apt install ./libwxgtk3.0-0_3.0.0-2_amd64.deb
-- wget https://github.com/NREL/OpenStudio/releases/download/v2.9.1/OpenStudio-2.9.1.3472e8b799-Linux.deb
-- sudo dpkg -i ./OpenStudio-2.9.1.3472e8b799-Linux.deb
+- wget https://github.com/NREL/OpenStudio/releases/download/v3.0.0/OpenStudio-3.0.0+1c9617fa4e-Linux.deb
+- sudo dpkg -i ./OpenStudio-3.0.0+1c9617fa4e-Linux.deb
 # install the openstudio extension gem
-- export RUBYLIB=/usr/local/openstudio-2.9.1/Ruby
-- gem install openstudio-extension -v 0.1.6
+- export RUBYLIB=/usr/local/openstudio-3.0.0/Ruby
+- gem install openstudio-extension -v 0.2.3
 
 install:
   - bundle install

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gemspec
 if File.exist?('../OpenStudio-extension-gem')  # local development copy
   gem 'openstudio-extension', path: '../OpenStudio-extension-gem'
 else  # get it from rubygems.org
-  gem 'openstudio-extension', '0.1.6'
+  gem 'openstudio-extension', '0.2.3'
 end
 
 # coveralls gem is used to generate coverage reports through CI

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](https://travis-ci.org/ladybug-tools/honeybee-openstudio-gem.svg?branch=master)](https://travis-ci.org/ladybug-tools/honeybee-openstudio-gem)
 [![Coverage Status](https://coveralls.io/repos/github/ladybug-tools/honeybee-openstudio-gem/badge.svg?branch=master)](https://coveralls.io/github/ladybug-tools/honeybee-openstudio-gem)
 
-![Ruby 2.2](https://img.shields.io/badge/ruby-2.2-blue.svg)
+![Ruby 2.5](https://img.shields.io/badge/ruby-2.5-blue.svg)
 
 # honeybee-openstudio-gem
 

--- a/honeybee-openstudio.gemspec
+++ b/honeybee-openstudio.gemspec
@@ -21,14 +21,14 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.14'
-  spec.add_development_dependency 'rake', '12.3.1'
-  spec.add_development_dependency 'rspec', '3.7.0'
+  spec.add_development_dependency 'bundler', '~> 2.1'
+  spec.add_development_dependency 'rake', '13.0'
+  spec.add_development_dependency 'rspec', '3.9'
   spec.add_development_dependency 'rubocop', '~> 0.54.0'
 
   spec.add_dependency 'json-schema'
   spec.add_dependency 'json_pure'
-  spec.add_dependency 'openstudio-extension', '0.1.6'
-  spec.add_dependency 'openstudio-standards', '~> 0.2.7'
+  spec.add_dependency 'openstudio-extension', '0.2.3'
+  spec.add_dependency 'openstudio-standards', '~> 0.2.11'
   spec.add_dependency 'public_suffix', '~> 3.1.1'
 end

--- a/lib/from_honeybee/schedule/ruleset.rb
+++ b/lib/from_honeybee/schedule/ruleset.rb
@@ -78,8 +78,8 @@ module FromHoneybee
         unless holiday_schedule.empty?
           holiday_schedule_object = holiday_schedule.get
           begin
-            os_sch_ruleset.setHolidaySchedule(holiday_schedule_object)  
-          rescue NoMethodError 
+            os_sch_ruleset.setHolidaySchedule(holiday_schedule_object)
+          rescue NoMethodError  # REMOVE: Once the upgrade to OpenStudio 3.0 is official
           end
         end
       end

--- a/lib/from_honeybee/simulation/parameter.rb
+++ b/lib/from_honeybee/simulation/parameter.rb
@@ -147,20 +147,45 @@ module FromHoneybee
 
       # set defaults for the Model's ShadowCalculation object
       os_shadow_calc = @openstudio_model.getShadowCalculation
-      os_shadow_calc.setCalculationFrequency(shdw_defaults[:calculation_frequency][:default])
-      os_shadow_calc.setMaximumFiguresInShadowOverlapCalculations(shdw_defaults[:maximum_figures][:default])
-      os_shadow_calc.setCalculationMethod(shdw_defaults[:calculation_method][:default])
+      begin
+        os_shadow_calc.setShadingCalculationUpdateFrequency(
+          shdw_defaults[:calculation_frequency][:default])
+      rescue NoMethodError  # REMOVE: Once the upgrade to OpenStudio 3.0 is official
+        os_shadow_calc.setCalculationFrequency(
+          shdw_defaults[:calculation_frequency][:default])
+      end
+      os_shadow_calc.setMaximumFiguresInShadowOverlapCalculations(
+        shdw_defaults[:maximum_figures][:default])
+      begin
+        os_shadow_calc.setShadingCalculationMethod(
+          shdw_defaults[:calculation_method][:default])
+      rescue NoMethodError  # REMOVE: Once the upgrade to OpenStudio 3.0 is official
+        os_shadow_calc.setCalculationMethod(
+          shdw_defaults[:calculation_method][:default])
+      end
 
       # override any ShadowCalculation defaults with lodaded JSON
       if @hash[:shadow_calculation]
         if @hash[:shadow_calculation][:calculation_frequency]
-          os_shadow_calc.setCalculationFrequency(@hash[:shadow_calculation][:calculation_frequency])
+          begin
+            os_shadow_calc.setShadingCalculationUpdateFrequency(
+              @hash[:shadow_calculation][:calculation_frequency])
+          rescue NoMethodError  # REMOVE: Once the upgrade to OpenStudio 3.0 is official
+            os_shadow_calc.setCalculationFrequency(
+              @hash[:shadow_calculation][:calculation_frequency])
+          end
         end
         if @hash[:shadow_calculation][:maximum_figures]
           os_shadow_calc.setMaximumFiguresInShadowOverlapCalculations(@hash[:shadow_calculation][:maximum_figures])
         end
         if @hash[:shadow_calculation][:calculation_method]
-          os_shadow_calc.setCalculationMethod(@hash[:shadow_calculation][:calculation_method])
+          begin
+            os_shadow_calc.setShadingCalculationMethod(
+              @hash[:shadow_calculation][:calculation_method])
+          rescue NoMethodError  # REMOVE: Once the upgrade to OpenStudio 3.0 is official
+            os_shadow_calc.setCalculationMethod(
+              @hash[:shadow_calculation][:calculation_method])
+          end
         end
         if @hash[:shadow_calculation][:solar_distribution]
           os_sim_control.setSolarDistribution(@hash[:shadow_calculation][:solar_distribution])
@@ -203,13 +228,14 @@ module FromHoneybee
         end
         if @hash[:output][:summary_reports]
           begin
+            os_report = @openstudio_model.getOutputTableSummaryReports
+          rescue  # REMOVE: Once the upgrade to OpenStudio 3.0 is official
             os_report = OpenStudio::Model::OutputTableSummaryReports.new(@openstudio_model)
-          rescue NameError
           end
           @hash[:output][:summary_reports].each do |report|
             begin
               os_report.addSummaryReport(report)
-            rescue NoMethodError
+            rescue NoMethodError  # REMOVE: Once the upgrade to OpenStudio 3.0 is official
             end
           end
         end

--- a/spec/tests/honeybee_simulation_parameter_spec.rb
+++ b/spec/tests/honeybee_simulation_parameter_spec.rb
@@ -78,11 +78,6 @@ RSpec.describe FromHoneybee do
     output_variable = openstudio_model.getOutputVariables
     expect(output_variable.size).to eq 6
     expect(output_variable[0].reportingFrequency).to eq 'Daily'
-        
-    shadow_calc = sim_contr.shadowCalculation
-    shadow_calc = shadow_calc.get
-    expect(shadow_calc.calculationFrequency).to eq 20
-    expect(shadow_calc.calculationMethod).to eq 'AverageOverDaysInFrequency'
   end
 
 end


### PR DESCRIPTION
BREAKING CHANGE: This commit officially upgrades the honeybee-openstudio-gem to work with OpenStudio 3.0. It also upgrades the version of the openstudio-extension-gem that we use to 0.2.3 among other dependencies.

The few OpenStudio SDK methods that have changed in OpenStudio 3.0 have been updated but the measure still techanically can run with OpenStudio 2.9.1 thanks to some `begin/rescue` statements.  I have marked all of these statements with a `# REMOVE:` comment so that we can go back later and delete them, thereby keeping the code clean.

Resolves https://github.com/ladybug-tools/honeybee-openstudio-gem/issues/98
Resolves https://github.com/ladybug-tools/honeybee-openstudio-gem/issues/15

@tanushree04 ,
I just requested your review here so that you are aware of the change. This effectively means that we are ready to switch to a version of URBANopt that supports OpenStudio 3.0 as soon as it is ready. Also, if you know of any dependencies that should be updated in the gemspec that I missed, just let me know and I'm happy to include them.