### PR TITLE
fix(ventcool): Set default discharge coefficient to 0.45 for deltaHnpl

### DIFF
--- a/lib/from_honeybee/_defaults/model.json
+++ b/lib/from_honeybee/_defaults/model.json
@@ -1485,8 +1485,8 @@
           },
           "discharge_coefficient": {
             "title": "Discharge Coefficient",
-            "description": "A number that will be multipled by the area of the window in the stack (buoyancy-driven) part of the equation to account for additional friction from window geometry, insect screens, etc. Typical values include 0.17, for unobstructed windows with insect screens and 0.25 for unobstructed windows without insect screens. This value should be lowered if windows are of an awning or casement type and not allowed to fully open.",
-            "default": 0.17,
+            "description": "A number that will be multipled by the area of the window in the stack (buoyancy-driven) part of the equation to account for additional friction from window geometry, insect screens, etc. Typical values include 0.45, for unobstructed windows WITH insect screens and 0.65 for unobstructed windows WITHOUT insect screens. This value should be lowered if windows are of an awning or casement type and not allowed to fully open.",
+            "default": 0.45,
             "minimum": 0,
             "maximum": 1,
             "type": "number",

--- a/lib/from_honeybee/ventcool/opening.rb
+++ b/lib/from_honeybee/ventcool/opening.rb
@@ -152,7 +152,8 @@ module FromHoneybee
           max_pt = v.z
         end
       end
-      max_pt - min_pt
+      # quarter the window height to get the height from midpoint of lower opening to neutral pressure level
+      (max_pt - min_pt) / 4
     end
 
   end #VentilationOpening

--- a/spec/samples/model/model_energy_window_ventilation.json
+++ b/spec/samples/model/model_energy_window_ventilation.json
@@ -244,7 +244,7 @@
                                         "type": "VentilationOpening",
                                         "fraction_area_operable": 0.5,
                                         "fraction_height_operable": 1.0,
-                                        "discharge_coefficient": 0.17,
+                                        "discharge_coefficient": 0.45,
                                         "wind_cross_vent": true
                                     }
                                 }
@@ -388,7 +388,7 @@
                                         "type": "VentilationOpening",
                                         "fraction_area_operable": 0.5,
                                         "fraction_height_operable": 1.0,
-                                        "discharge_coefficient": 0.17,
+                                        "discharge_coefficient": 0.45,
                                         "wind_cross_vent": true
                                     }
                                 }

--- a/spec/samples/ventcool/ventilation_opening_default.json
+++ b/spec/samples/ventcool/ventilation_opening_default.json
@@ -2,6 +2,6 @@
     "type": "VentilationOpening",
     "fraction_area_operable": 0.5,
     "fraction_height_operable": 1.0,
-    "discharge_coefficient": 0.17,
+    "discharge_coefficient": 0.45,
     "wind_cross_vent": false
 }


### PR DESCRIPTION
If we want to use the discharge coefficient in both simple ventilation and the AFN, it seems we should follow the E+ guide and use a coefficient that corresponds to the height from midpoint of lower opening to the neutral pressure level (deltaHnpl) instead of using the full height of the window.