### PR TITLE
feat(afn): Add methods and classes to translate honeybee_schema AFN

### DIFF
--- a/lib/from_honeybee/_defaults/model.json
+++ b/lib/from_honeybee/_defaults/model.json
@@ -25,6 +25,11 @@
   },
   "tags": [
     {
+      "name": "afncrack_model",
+      "x-displayName": "AFNCrack",
+      "description": "<SchemaDefinition schemaRef=\"#/components/schemas/AFNCrack\" />\n"
+    },
+    {
       "name": "adiabatic_model",
       "x-displayName": "Adiabatic",
       "description": "<SchemaDefinition schemaRef=\"#/components/schemas/Adiabatic\" />\n"
@@ -108,6 +113,16 @@
       "name": "baseboardequipmenttype_model",
       "x-displayName": "BaseboardEquipmentType",
       "description": "<SchemaDefinition schemaRef=\"#/components/schemas/BaseboardEquipmentType\" />\n"
+    },
+    {
+      "name": "buildingtype_model",
+      "x-displayName": "BuildingType",
+      "description": "<SchemaDefinition schemaRef=\"#/components/schemas/BuildingType\" />\n"
+    },
+    {
+      "name": "color_model",
+      "x-displayName": "Color",
+      "description": "<SchemaDefinition schemaRef=\"#/components/schemas/Color\" />\n"
     },
     {
       "name": "constructionset_model",
@@ -385,6 +400,11 @@
       "description": "<SchemaDefinition schemaRef=\"#/components/schemas/LightingAbridged\" />\n"
     },
     {
+      "name": "mesh3d_model",
+      "x-displayName": "Mesh3D",
+      "description": "<SchemaDefinition schemaRef=\"#/components/schemas/Mesh3D\" />\n"
+    },
+    {
       "name": "metal_model",
       "x-displayName": "Metal",
       "description": "<SchemaDefinition schemaRef=\"#/components/schemas/Metal\" />\n"
@@ -615,6 +635,16 @@
       "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ScheduleUnitType\" />\n"
     },
     {
+      "name": "sensor_model",
+      "x-displayName": "Sensor",
+      "description": "<SchemaDefinition schemaRef=\"#/components/schemas/Sensor\" />\n"
+    },
+    {
+      "name": "sensorgrid_model",
+      "x-displayName": "SensorGrid",
+      "description": "<SchemaDefinition schemaRef=\"#/components/schemas/SensorGrid\" />\n"
+    },
+    {
       "name": "setpoint_model",
       "x-displayName": "Setpoint",
       "description": "<SchemaDefinition schemaRef=\"#/components/schemas/Setpoint\" />\n"
@@ -735,9 +765,29 @@
       "description": "<SchemaDefinition schemaRef=\"#/components/schemas/VentilationControlAbridged\" />\n"
     },
     {
+      "name": "ventilationcontroltype_model",
+      "x-displayName": "VentilationControlType",
+      "description": "<SchemaDefinition schemaRef=\"#/components/schemas/VentilationControlType\" />\n"
+    },
+    {
       "name": "ventilationopening_model",
       "x-displayName": "VentilationOpening",
       "description": "<SchemaDefinition schemaRef=\"#/components/schemas/VentilationOpening\" />\n"
+    },
+    {
+      "name": "ventilationsimulationcontrol_model",
+      "x-displayName": "VentilationSimulationControl",
+      "description": "<SchemaDefinition schemaRef=\"#/components/schemas/VentilationSimulationControl\" />\n"
+    },
+    {
+      "name": "view_model",
+      "x-displayName": "View",
+      "description": "<SchemaDefinition schemaRef=\"#/components/schemas/View\" />\n"
+    },
+    {
+      "name": "viewtype_model",
+      "x-displayName": "ViewType",
+      "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ViewType\" />\n"
     },
     {
       "name": "vintages_model",
@@ -825,6 +875,7 @@
       "name": "Models",
       "tags": [
         "adiabatic_model",
+        "afncrack_model",
         "airboundaryconstruction_model",
         "airboundaryconstructionabridged_model",
         "allaireconomizertype_model",
@@ -841,6 +892,8 @@
         "baseboard_model",
         "baseboardequipmenttype_model",
         "bsdf_model",
+        "buildingtype_model",
+        "color_model",
         "constructionset_model",
         "constructionsetabridged_model",
         "controltype_model",
@@ -896,6 +949,7 @@
         "light_model",
         "lighting_model",
         "lightingabridged_model",
+        "mesh3d_model",
         "metal_model",
         "mirror_model",
         "model_model",
@@ -942,6 +996,8 @@
         "schedulerulesetabridged_model",
         "scheduletypelimit_model",
         "scheduleunittype_model",
+        "sensor_model",
+        "sensorgrid_model",
         "setpoint_model",
         "setpointabridged_model",
         "shade_model",
@@ -962,7 +1018,11 @@
         "ventilation_model",
         "ventilationabridged_model",
         "ventilationcontrolabridged_model",
+        "ventilationcontroltype_model",
         "ventilationopening_model",
+        "ventilationsimulationcontrol_model",
+        "view_model",
+        "viewtype_model",
         "vintages_model",
         "void_model",
         "vrf_model",
@@ -1476,7 +1536,7 @@
           },
           "fraction_height_operable": {
             "title": "Fraction Height Operable",
-            "description": "A number for the fraction of the distance from the bottom of the window to the top that is operable.",
+            "description": "A number for the fraction of the distance from the bottom of the window to the top that is operable",
             "default": 1.0,
             "minimum": 0,
             "maximum": 1,
@@ -1485,7 +1545,7 @@
           },
           "discharge_coefficient": {
             "title": "Discharge Coefficient",
-            "description": "A number that will be multipled by the area of the window in the stack (buoyancy-driven) part of the equation to account for additional friction from window geometry, insect screens, etc. Typical values include 0.45, for unobstructed windows WITH insect screens and 0.65 for unobstructed windows WITHOUT insect screens. This value should be lowered if windows are of an awning or casement type and not allowed to fully open.",
+            "description": "A number that will be multipled by the area of the window in the stack (buoyancy-driven) part of the equation to account for additional friction from window geometry, insect screens, etc. Typical values include 0.45, for unobstructed windows WITH insect screens and 0.65 for unobstructed windows WITHOUT insect screens. This value should be lowered if windows are of an awning or casement type and are not allowed to fully open.",
             "default": 0.45,
             "minimum": 0,
             "maximum": 1,
@@ -1497,6 +1557,30 @@
             "description": "Boolean to indicate if there is an opening of roughly equal area on the opposite side of the Room such that wind-driven cross ventilation will be induced. If False, the assumption is that the operable area is primarily on one side of the Room and there is no wind-driven ventilation.",
             "default": false,
             "type": "boolean"
+          },
+          "flow_coefficient_closed": {
+            "title": "Flow Coefficient Closed",
+            "description": "An optional number in kg/s-m, at 1 Pa per meter of crack length, used to calculate the mass flow rate when the opening is closed; required to run an AirflowNetwork simulation. The DesignBuilder Cracks template defines the flow coefficient for a tight, low-leakage closed external window to be 0.00001, and the flow coefficient for a very poor, high-leakage closed external window to be 0.003.",
+            "minimum": 0,
+            "type": "number",
+            "format": "double"
+          },
+          "flow_exponent_closed": {
+            "title": "Flow Exponent Closed",
+            "description": "An optional dimensionless number between 0.5 and 1 used to calculate the mass flow rate when the opening is closed; required to run an AirflowNetwork simulation. This value represents the leak geometry impact on airflow, with 0.5 generally corresponding to turbulent orifice flow and 1 generally corresponding to laminar flow. The default of 0.65 is representative of many cases of wall and window leakage, used when the exponent cannot be measured.",
+            "default": 0.65,
+            "minimum": 0.5,
+            "maximum": 1,
+            "type": "number",
+            "format": "double"
+          },
+          "two_way_threshold": {
+            "title": "Two Way Threshold",
+            "description": "A number in kg/m3 indicating the minimum density difference above which two-way flow may occur due to stack effect, required to run an AirflowNetwork simulation. This value is required because the air density difference between two zones (which drives two-way air flow) will tend towards division by zero errors as the air density difference approaches zero. The default of 0.0001 is a typical default value used for AirflowNetwork openings.",
+            "default": 0.0001,
+            "exclusiveMinimum": 0,
+            "type": "number",
+            "format": "double"
           }
         },
         "additionalProperties": false
@@ -1908,6 +1992,40 @@
         ],
         "additionalProperties": false
       },
+      "AFNCrack": {
+        "title": "AFNCrack",
+        "description": "Properties for airflow through a crack.",
+        "type": "object",
+        "properties": {
+          "flow_coefficient": {
+            "title": "Flow Coefficient",
+            "description": "A number in kg/s-m at 1 Pa per meter of crack length at the conditions defined in the ReferenceCrack condition; required to run an AirflowNetwork simulation. The DesignBuilder Cracks template defines the flow coefficient for a tight, low-leakage wall to be 0.00001 and 0.001 for external and internal constructions, respectively. Flow coefficients for a very poor, high-leakage wall are defined to be 0.0004 and 0.019 for external and internal constructions, respectively.",
+            "exclusiveMinimum": 0,
+            "type": "number",
+            "format": "double"
+          },
+          "type": {
+            "title": "Type",
+            "default": "AFNCrack",
+            "pattern": "^AFNCrack$",
+            "type": "string",
+            "readOnly": true
+          },
+          "flow_exponent": {
+            "title": "Flow Exponent",
+            "description": "An optional dimensionless number between 0.5 and 1 used to calculate the crack mass flow rate; required to run an AirflowNetwork simulation. This value represents the leak geometry impact on airflow, with 0.5 generally corresponding to turbulent orifice flow and 1 generally corresponding to laminar flow. The default of 0.65 is representative of many cases of wall and window leakage, used when the exponent cannot be measured.",
+            "default": 0.65,
+            "minimum": 0.5,
+            "maximum": 1,
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "required": [
+          "flow_coefficient"
+        ],
+        "additionalProperties": false
+      },
       "FaceEnergyPropertiesAbridged": {
         "title": "FaceEnergyPropertiesAbridged",
         "description": "Base class for all objects that are not extensible with additional keys.\n\nThis effectively includes all objects except for the Properties classes\nthat are assigned to geometry objects.",
@@ -1926,6 +2044,15 @@
             "maxLength": 100,
             "minLength": 1,
             "type": "string"
+          },
+          "vent_crack": {
+            "title": "Vent Crack",
+            "description": "An optional AFNCrack to specify airflow through a surface crack used by the AirflowNetwork.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AFNCrack"
+              }
+            ]
           }
         },
         "additionalProperties": false
@@ -8069,6 +8196,103 @@
         ],
         "additionalProperties": false
       },
+      "VentilationControlType": {
+        "title": "VentilationControlType",
+        "description": "An enumeration.",
+        "enum": [
+          "SingleZone",
+          "MultiZoneWithDistribution",
+          "MultiZoneWithoutDistribution"
+        ],
+        "type": "string"
+      },
+      "BuildingType": {
+        "title": "BuildingType",
+        "description": "An enumeration.",
+        "enum": [
+          "LowRise",
+          "HighRise"
+        ],
+        "type": "string"
+      },
+      "VentilationSimulationControl": {
+        "title": "VentilationSimulationControl",
+        "description": "The global parameters used in the ventilation simulation.",
+        "type": "object",
+        "properties": {
+          "type": {
+            "title": "Type",
+            "default": "VentilationSimulationControl",
+            "pattern": "^VentilationSimulationControl$",
+            "type": "string",
+            "readOnly": true
+          },
+          "vent_control_type": {
+            "title": "Vent Control Type",
+            "description": "Text indicating type of ventilation control. Choices are: SingleZone, MultiZoneWithDistribution, MultiZoneWithoutDistribution. The MultiZone options will model air flow with the AirflowNetwork model, which is generally more accurate then the SingleZone option, but will take considerably longer to simulate, and requires defining more ventilation parameters to explicitly account for weather and building-induced pressure differences, and the leakage geometry corresponding to specific windows, doors, and surface cracks.",
+            "default": "SingleZone",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/VentilationControlType"
+              }
+            ]
+          },
+          "reference_temperature": {
+            "title": "Reference Temperature",
+            "description": "Reference temperature measurement in Celsius under which the surface crack data were obtained.",
+            "default": 20,
+            "minimum": -273.15,
+            "type": "number",
+            "format": "double"
+          },
+          "reference_pressure": {
+            "title": "Reference Pressure",
+            "description": "Reference barometric pressure measurement in Pascals under which the surface crack data were obtained.",
+            "default": 101325,
+            "minimum": 31000,
+            "maximum": 120000,
+            "type": "number",
+            "format": "double"
+          },
+          "reference_humidity_ratio": {
+            "title": "Reference Humidity Ratio",
+            "description": "Reference humidity ratio measurement in kgWater/kgDryAir under which the surface crack data were obtained.",
+            "default": 0,
+            "minimum": 0,
+            "type": "number",
+            "format": "double"
+          },
+          "building_type": {
+            "title": "Building Type",
+            "description": "Text indicating relationship between building footprint and height used to calculate the wind pressure coefficients for exterior surfaces.Choices are: LowRise and HighRise. LowRise corresponds to rectangular building whose height is less then three times the width and length of the footprint. HighRise corresponds to a rectangular building whose height is more than three times the width and length of the footprint. This parameter is required to automatically calculate wind pressure coefficients for the AirflowNetwork simulation. If used for complex building geometries that cannot be described as a highrise or lowrise rectangular mass, the resulting air flow and pressure simulated on the building surfaces may be inaccurate.",
+            "default": "LowRise",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingType"
+              }
+            ]
+          },
+          "long_axis_angle": {
+            "title": "Long Axis Angle",
+            "description": "The clockwise rotation in degrees from true North of the long axis of the building. This parameter is required to automatically calculate wind pressure coefficients for the AirflowNetwork simulation. If used for complex building geometries that cannot be described as a highrise or lowrise rectangular mass, the resulting air flow and pressure simulated on the building surfaces may be inaccurate.",
+            "default": 0,
+            "minimum": 0,
+            "maximum": 180,
+            "type": "number",
+            "format": "double"
+          },
+          "aspect_ratio": {
+            "title": "Aspect Ratio",
+            "description": "Aspect ratio of a rectangular footprint, defined as the ratio of length of the short axis divided by the length of the long axis. This parameter is required to automatically calculate wind pressure coefficients for the AirflowNetwork simulation. If used for complex building geometries that cannot be described as a highrise or lowrise rectangular mass, the resulting air flow and pressure simulated on the building surfaces may be inaccurate.",
+            "default": 1,
+            "exclusiveMinimum": 0,
+            "maximum": 1,
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "additionalProperties": false
+      },
       "ModelEnergyProperties": {
         "title": "ModelEnergyProperties",
         "description": "Base class for all objects that are not extensible with additional keys.\n\nThis effectively includes all objects except for the Properties classes\nthat are assigned to geometry objects.",
@@ -8271,6 +8495,15 @@
             "items": {
               "$ref": "#/components/schemas/ScheduleTypeLimit"
             }
+          },
+          "ventilation_simulation_control": {
+            "title": "Ventilation Simulation Control",
+            "description": "An optional parameter to define the global parameters for a ventilation cooling.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/VentilationSimulationControl"
+              }
+            ]
           }
         },
         "additionalProperties": false
@@ -10503,6 +10736,356 @@
         ],
         "additionalProperties": false
       },
+      "Sensor": {
+        "title": "Sensor",
+        "description": "A single Radiance of sensors.",
+        "type": "object",
+        "properties": {
+          "pos": {
+            "title": "Pos",
+            "description": "Position of sensor in space as an array of (x, y, z) values.",
+            "minItems": 3,
+            "maxItems": 3,
+            "type": "array",
+            "items": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          "dir": {
+            "title": "Dir",
+            "description": "Direction of sensor as an array of (x, y, z) values.",
+            "minItems": 3,
+            "maxItems": 3,
+            "type": "array",
+            "items": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          "type": {
+            "title": "Type",
+            "default": "Sensor",
+            "pattern": "^Sensor$",
+            "type": "string",
+            "readOnly": true
+          }
+        },
+        "required": [
+          "pos",
+          "dir"
+        ],
+        "additionalProperties": false
+      },
+      "Color": {
+        "title": "Color",
+        "description": "A mesh in 3D space.",
+        "type": "object",
+        "properties": {
+          "r": {
+            "title": "R",
+            "description": "Integer for red value.",
+            "minimum": 0,
+            "maximum": 255,
+            "type": "integer",
+            "format": "int32"
+          },
+          "g": {
+            "title": "G",
+            "description": "Integer for green value.",
+            "minimum": 0,
+            "maximum": 255,
+            "type": "integer",
+            "format": "int32"
+          },
+          "b": {
+            "title": "B",
+            "description": "Integer for blue value.",
+            "minimum": 0,
+            "maximum": 255,
+            "type": "integer",
+            "format": "int32"
+          },
+          "type": {
+            "title": "Type",
+            "default": "Color",
+            "pattern": "^Color$",
+            "type": "string",
+            "readOnly": true
+          }
+        },
+        "required": [
+          "r",
+          "g",
+          "b"
+        ],
+        "additionalProperties": false
+      },
+      "Mesh3D": {
+        "title": "Mesh3D",
+        "description": "A mesh in 3D space.",
+        "type": "object",
+        "properties": {
+          "vertices": {
+            "title": "Vertices",
+            "description": "A list of points representing the vertices of the mesh. The list should include at least 3 points and each point should be a list of 3 (x, y, z) values.",
+            "minItems": 3,
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "number",
+                "format": "double"
+              },
+              "minItems": 3,
+              "maxItems": 3
+            }
+          },
+          "faces": {
+            "title": "Faces",
+            "description": "A list of lists with each sub-list having either 3 or 4 integers. These integers correspond to indices within the list of vertices.",
+            "minItems": 1,
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int32"
+              },
+              "minItems": 3,
+              "maxItems": 4
+            }
+          },
+          "type": {
+            "title": "Type",
+            "default": "Mesh3D",
+            "pattern": "^Mesh3D$",
+            "type": "string",
+            "readOnly": true
+          },
+          "colors": {
+            "title": "Colors",
+            "description": "An optional list of colors that correspond to either the faces of the mesh or the vertices of the mesh.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Color"
+            }
+          }
+        },
+        "required": [
+          "vertices",
+          "faces"
+        ],
+        "additionalProperties": false
+      },
+      "SensorGrid": {
+        "title": "SensorGrid",
+        "description": "A grid of sensors.",
+        "type": "object",
+        "properties": {
+          "identifier": {
+            "title": "Identifier",
+            "description": "Text string for a unique Radiance object. Must not contain spaces or special characters. This will be used to identify the object across a model and in the exported Radiance files.",
+            "type": "string"
+          },
+          "sensors": {
+            "title": "Sensors",
+            "description": "A list of sensors that belong to the grid.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Sensor"
+            }
+          },
+          "display_name": {
+            "title": "Display Name",
+            "description": "Text string for a unique display name, used to set the default file name that the radiance asset is written to within a radiance folder. Must not contain spaces or special characters.",
+            "type": "string"
+          },
+          "room_identifier": {
+            "title": "Room Identifier",
+            "description": "Optional text string for the Room identifier to which this object belongs. This will be used to narrow down the number of aperture groups that have to be run with this sensor grid. If None, the grid will be run with all aperture groups in the model.",
+            "maxLength": 100,
+            "minLength": 1,
+            "pattern": "[A-Za-z0-9_-]",
+            "type": "string"
+          },
+          "light_path": {
+            "title": "Light Path",
+            "description": "Get or set a list of lists for the light path from the object to the sky. Each sub-list contains identifiers of aperture groups through which light passes. (eg. [[\"SouthWindow1\"], [\"static_apertures\", \"NorthWindow2\"]]).Setting this property will override any auto-calculation of the light path from the model and room_identifier upon export to the simulation.",
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "type": {
+            "title": "Type",
+            "default": "SensorGrid",
+            "pattern": "^SensorGrid$",
+            "type": "string",
+            "readOnly": true
+          },
+          "mesh": {
+            "title": "Mesh",
+            "description": "An optional Mesh3D that aligns with the sensors and can be used for visualization of the grid. Note that the number of sensors in the grid must match the number of faces or the number vertices within the Mesh3D.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Mesh3D"
+              }
+            ]
+          }
+        },
+        "required": [
+          "identifier",
+          "sensors"
+        ],
+        "additionalProperties": false
+      },
+      "ViewType": {
+        "title": "ViewType",
+        "description": "A single character for the view type (-vt).",
+        "enum": [
+          "v",
+          "h",
+          "l",
+          "c",
+          "a",
+          "s"
+        ],
+        "type": "string"
+      },
+      "View": {
+        "title": "View",
+        "description": "A single Radiance of sensors.",
+        "type": "object",
+        "properties": {
+          "identifier": {
+            "title": "Identifier",
+            "description": "Text string for a unique Radiance object. Must not contain spaces or special characters. This will be used to identify the object across a model and in the exported Radiance files.",
+            "type": "string"
+          },
+          "position": {
+            "title": "Position",
+            "description": "The view position (-vp) as an array of (x, y, z) values.This is the focal point of a perspective view or the center of a parallel projection.",
+            "minItems": 3,
+            "maxItems": 3,
+            "type": "array",
+            "items": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          "direction": {
+            "title": "Direction",
+            "description": "The view direction (-vd) as an array of (x, y, z) values.The length of this vector indicates the focal distance as needed by the pixel depth of field (-pd) in rpict.",
+            "minItems": 3,
+            "maxItems": 3,
+            "type": "array",
+            "items": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          "up_vector": {
+            "title": "Up Vector",
+            "description": "The view up (-vu) vector as an array of (x, y, z) values.",
+            "minItems": 3,
+            "maxItems": 3,
+            "type": "array",
+            "items": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          "display_name": {
+            "title": "Display Name",
+            "description": "Text string for a unique display name, used to set the default file name that the radiance asset is written to within a radiance folder. Must not contain spaces or special characters.",
+            "type": "string"
+          },
+          "room_identifier": {
+            "title": "Room Identifier",
+            "description": "Optional text string for the Room identifier to which this object belongs. This will be used to narrow down the number of aperture groups that have to be run with this sensor grid. If None, the grid will be run with all aperture groups in the model.",
+            "maxLength": 100,
+            "minLength": 1,
+            "pattern": "[A-Za-z0-9_-]",
+            "type": "string"
+          },
+          "light_path": {
+            "title": "Light Path",
+            "description": "Get or set a list of lists for the light path from the object to the sky. Each sub-list contains identifiers of aperture groups through which light passes. (eg. [[\"SouthWindow1\"], [\"static_apertures\", \"NorthWindow2\"]]).Setting this property will override any auto-calculation of the light path from the model and room_identifier upon export to the simulation.",
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "type": {
+            "title": "Type",
+            "default": "View",
+            "pattern": "^View$",
+            "type": "string",
+            "readOnly": true
+          },
+          "view_type": {
+            "title": "View Type",
+            "default": "v",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ViewType"
+              }
+            ]
+          },
+          "h_size": {
+            "title": "H Size",
+            "description": "A number for the horizontal field of view in degrees (for all perspective projections including fisheye). For a parallel projection, this is the view width in world coordinates.",
+            "default": 60,
+            "type": "number",
+            "format": "double"
+          },
+          "v_size": {
+            "title": "V Size",
+            "description": "A number for the vertical field of view in degrees (for all perspective projections including fisheye). For a parallel projection, this is the view width in world coordinates.",
+            "default": 60,
+            "type": "number",
+            "format": "double"
+          },
+          "shift": {
+            "title": "Shift",
+            "description": "The view shift (-vs). This is the amount the actual image will be shifted to the right of the specified view. This option is useful for generating skewed perspectives or rendering an image a piece at a time. A value of 1 means that the rendered image starts just to the right of the normal view. A value of -1 would be to the left. Larger or fractional values are permitted as well.",
+            "type": "number",
+            "format": "double"
+          },
+          "lift": {
+            "title": "Lift",
+            "description": "The view lift (-vl). This is the amount the actual image will be lifted up from the specified view. This option is useful for generating skewed perspectives or rendering an image a piece at a time. A value of 1 means that the rendered image starts just to the right of the normal view. A value of -1 would be to the left. Larger or fractional values are permitted as well.",
+            "type": "number",
+            "format": "double"
+          },
+          "fore_clip": {
+            "title": "Fore Clip",
+            "description": "View fore clip (-vo) at a distance from the view point.The plane will be perpendicular to the view direction for perspective and parallel view types. For fisheye view types, the clipping plane is actually a clipping sphere, centered on the view point with fore_clip radius. Objects in front of this imaginary surface will not be visible.",
+            "type": "number",
+            "format": "double"
+          },
+          "aft_clip": {
+            "title": "Aft Clip",
+            "description": "View aft clip (-va) at a distance from the view point.Like the view fore plane, it will be perpendicular to the view direction for perspective and parallel view types. For fisheye view types, the clipping plane is actually a clipping sphere, centered on the view point with radius val.",
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "required": [
+          "identifier",
+          "position",
+          "direction",
+          "up_vector"
+        ],
+        "additionalProperties": false
+      },
       "ModelRadianceProperties": {
         "title": "ModelRadianceProperties",
         "description": "Radiance Properties for Honeybee Model.",
@@ -10517,7 +11100,7 @@
           },
           "modifiers": {
             "title": "Modifiers",
-            "description": "A list of all unique modifiers in the model. This includes modifiers across all Faces, Apertures, Doors, Shades, Room ModifierSets, and the global_modifier_set (default: None).",
+            "description": "A list of all unique modifiers in the model. This includes modifiers across all Faces, Apertures, Doors, Shades, Room ModifierSets, and the global_modifier_set.",
             "type": "array",
             "items": {
               "anyOf": [
@@ -10553,7 +11136,7 @@
           },
           "modifier_sets": {
             "title": "Modifier Sets",
-            "description": "A list of all unique Room-Assigned ModifierSets in the Model (default: None).",
+            "description": "A list of all unique Room-Assigned ModifierSets in the Model.",
             "type": "array",
             "items": {
               "anyOf": [
@@ -10564,6 +11147,22 @@
                   "$ref": "#/components/schemas/ModifierSetAbridged"
                 }
               ]
+            }
+          },
+          "sensor_grids": {
+            "title": "Sensor Grids",
+            "description": "An array of SensorGrids that are associated with the model.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SensorGrid"
+            }
+          },
+          "views": {
+            "title": "Views",
+            "description": "An array of Views that are associated with the model.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/View"
             }
           }
         },

--- a/lib/from_honeybee/program_type.rb
+++ b/lib/from_honeybee/program_type.rb
@@ -94,14 +94,14 @@ module FromHoneybee
         os_gas_equipment = gas_equipment.to_openstudio(openstudio_model)
         os_gas_equipment.setSpaceType(os_space_type)
       end
-        
+
       # assign infiltration
-      if @hash[:infiltration]
+      if @hash[:infiltration] && $use_simple_vent  # only use infiltration with simple ventilation
         infiltration = InfiltrationAbridged.new(@hash[:infiltration])
         os_infiltration = infiltration.to_openstudio(openstudio_model)
         os_infiltration.setSpaceType(os_space_type)
       end
-    
+
       # assign ventilation
       if @hash[:ventilation]
         ventilation = VentilationAbridged.new(@hash[:ventilation])

--- a/lib/from_honeybee/ventcool/control.rb
+++ b/lib/from_honeybee/ventcool/control.rb
@@ -1,0 +1,161 @@
+# *******************************************************************************
+# Honeybee OpenStudio Gem, Copyright (c) 2020, Alliance for Sustainable 
+# Energy, LLC, Ladybug Tools LLC and other contributors. All rights reserved.
+# 
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# (1) Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# (2) Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# (3) Neither the name of the copyright holder nor the names of any contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission from the respective party.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER(S) AND ANY CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER(S), ANY CONTRIBUTORS, THE
+# UNITED STATES GOVERNMENT, OR THE UNITED STATES DEPARTMENT OF ENERGY, NOR ANY OF
+# THEIR EMPLOYEES, BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+# OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# *******************************************************************************
+
+require 'from_honeybee/model_object'
+
+require 'openstudio'
+
+module FromHoneybee
+  class VentilationControl < ModelObject
+    attr_reader :errors, :warnings
+    @@outdoor_node = nil
+    @@program_manager = nil
+
+    def initialize(hash = {})
+      super(hash)
+    end
+
+    def defaults
+      @@schema[:components][:schemas][:VentilationControlAbridged][:properties]
+    end
+
+    def get_outdoor_node(openstudio_model)
+      # get the EMS sensor for the outdoor node if it exists or generate it if it doesn't
+      if @@outdoor_node.nil?
+        out_var = OpenStudio::Model::OutputVariable.new(
+          'Site Outdoor Air Drybulb Temperature', openstudio_model)
+        out_var.setReportingFrequency('Timestep')
+        out_var.setKeyValue('Environment')
+        @@outdoor_node = OpenStudio::Model::EnergyManagementSystemSensor.new(
+          openstudio_model, out_var)
+        @@outdoor_node.setName('Outdoor_Sensor')
+      end
+      @@outdoor_node
+    end
+
+    def get_program_manager(openstudio_model)
+      # get the EMS Program Manager for all window opening if it exists or generate it if it doesn't
+      if @@program_manager.nil?
+        @@program_manager = OpenStudio::Model::EnergyManagementSystemProgramCallingManager.new(
+          openstudio_model)
+        @@program_manager.setName('Temperature_Controlled_Window_Opening')
+        @@program_manager.setCallingPoint('BeginTimestepBeforePredictor')
+      end
+      @@program_manager
+      end
+
+    def to_openstudio(openstudio_model, parent_zone, vent_opening_surfaces, vent_opening_factors)
+      # Get the outdoor temperature sensor and the room air temperature sensor
+      out_air_temp = get_outdoor_node(openstudio_model)
+      in_var = OpenStudio::Model::OutputVariable.new('Zone Air Temperature', openstudio_model)
+      in_var.setReportingFrequency('Timestep')
+      zone_name = parent_zone.name
+      os_zone_name = 'Indoor'
+      unless zone_name.empty?
+        os_zone_name = zone_name.get
+        in_var.setKeyValue(os_zone_name)
+      end
+      in_air_temp = OpenStudio::Model::EnergyManagementSystemSensor.new(openstudio_model, in_var)
+      in_sensor_name = os_zone_name.delete(' ').delete('.') + '_Sensor'
+      in_air_temp.setName(in_sensor_name)
+
+      # create the actuators for each of the operaable windows
+      actuator_names = []
+      vent_opening_surfaces.each do |vent_srf|
+        window_act = OpenStudio::Model::EnergyManagementSystemActuator.new(
+            vent_srf, 'AirFlow Network Window/Door Opening', 'Venting Opening Factor')
+        vent_srf_name = vent_srf.name
+        unless vent_srf_name.empty?
+          act_name = vent_srf_name.get.delete(' ').delete('.') + '_OpenFactor'
+          window_act.setName(act_name)
+          actuator_names << act_name
+        end
+      end
+
+      # create the first line of the EMS Program to open each window according to the control logic
+      logic_statements = []
+      # check the minimum indoor tempertaure for ventilation
+      min_in = @hash[:min_indoor_temperature]
+      if min_in && min_in != defaults[:min_indoor_temperature][:default]
+        logic_statements << '(' + in_sensor_name + ' > ' + min_in.to_s + ')'
+      end
+      # check the maximum indoor tempertaure for ventilation
+      max_in = @hash[:max_indoor_temperature]
+      if max_in && max_in != defaults[:max_indoor_temperature][:default]
+        logic_statements << '(' + in_sensor_name + ' < ' + max_in.to_s + ')'
+      end
+      # check the minimum outdoor tempertaure for ventilation
+      min_out = @hash[:min_outdoor_temperature]
+      if min_out && min_out != defaults[:min_outdoor_temperature][:default]
+        logic_statements << '(Outdoor_Sensor > ' + min_out.to_s + ')'
+      end
+      # check the maximum outdoor tempertaure for ventilation
+      max_out = @hash[:max_outdoor_temperature]
+      if max_out && max_out != defaults[:max_outdoor_temperature][:default]
+        logic_statements << '(Outdoor_Sensor < ' + max_out.to_s + ')'
+      end
+      # check the delta tempertaure for ventilation
+      delta_in_out = @hash[:delta_temperature]
+      if delta_in_out && delta_in_out != defaults[:delta_temperature][:default]
+        logic_statements << '((' + in_sensor_name + ' - Outdoor_Sensor) > ' + delta_in_out.to_s + ')'
+      end
+      # create the complete logic statement for opening windows
+      if logic_statements.empty?
+        complete_logic = 'IF (Outdoor_Sensor < 100)'  # no logic has been provided; always open windows
+      else
+        complete_logic = 'IF ' + logic_statements.join(' && ')
+      end
+
+      # initialize the program and add the complete logic
+      ems_program = OpenStudio::Model::EnergyManagementSystemProgram.new(openstudio_model)
+      ems_program.setName(os_zone_name.delete(' ').delete('.') + '_WindowOpening')
+      ems_program.addLine(complete_logic)
+
+      # loop through each of the actuators and open each window
+      actuator_names.zip(vent_opening_factors).each do |act_name, open_factor|
+        ems_program.addLine('SET ' + act_name + ' = ' + open_factor.to_s)
+      end
+      # loop through each of the actuators and close each window
+      ems_program.addLine('ELSE')
+      actuator_names.each do |act_name|
+        ems_program.addLine('SET ' + act_name + ' = 0')
+      end
+      ems_program.addLine('ENDIF')
+      
+      # add the program object the the global program manager for all window opening
+      prog_manager = get_program_manager(openstudio_model)
+      prog_manager.addProgram(ems_program)
+
+      ems_program
+    end
+
+    end #VentilationControl
+end #FromHoneybee

--- a/lib/from_honeybee/ventcool/simulation.rb
+++ b/lib/from_honeybee/ventcool/simulation.rb
@@ -1,0 +1,110 @@
+# *******************************************************************************
+# Honeybee OpenStudio Gem, Copyright (c) 2020, Alliance for Sustainable 
+# Energy, LLC, Ladybug Tools LLC and other contributors. All rights reserved.
+# 
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# (1) Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# (2) Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# (3) Neither the name of the copyright holder nor the names of any contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission from the respective party.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER(S) AND ANY CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER(S), ANY CONTRIBUTORS, THE
+# UNITED STATES GOVERNMENT, OR THE UNITED STATES DEPARTMENT OF ENERGY, NOR ANY OF
+# THEIR EMPLOYEES, BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+# OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# *******************************************************************************
+
+require 'from_honeybee/model_object'
+
+require 'openstudio'
+
+module FromHoneybee
+  class VentilationSimulationControl < ModelObject
+    attr_reader :errors, :warnings
+
+    def initialize(hash = {})
+      super(hash)
+    end
+
+    def defaults
+      @@schema[:components][:schemas][:VentilationSimulationControl][:properties]
+    end
+
+    def to_openstudio(openstudio_model)
+      # create the AirflowNetworkSimulationControl object
+      os_vsim_control = openstudio_model.getAirflowNetworkSimulationControl
+      os_vsim_control.setName('Window Based Ventilative Cooling')
+
+      # assign the control type
+      if @hash[:vent_control_type]
+        os_vsim_control.setAirflowNetworkControl(@hash[:vent_control_type])
+      else
+        os_vsim_control.setAirflowNetworkControl('MultizoneWithoutDistribution')
+      end
+
+      # assign the building type
+      if @hash[:building_type]
+        os_vsim_control.setBuildingType(@hash[:building_type])
+      else
+        os_vsim_control.setBuildingType(defaults[:building_type][:default])
+      end
+
+      # assign the long axis azimth angle of the building
+      if @hash[:long_axis_angle]
+        os_vsim_control.setAzimuthAngleofLongAxisofBuilding(@hash[:long_axis_angle])
+      else
+        os_vsim_control.setAzimuthAngleofLongAxisofBuilding(defaults[:long_axis_angle][:default])
+      end
+
+      # assign the aspect ratio of the building
+      if @hash[:aspect_ratio]
+        os_vsim_control.setBuildingAspectRatio(@hash[:aspect_ratio])
+      else
+        os_vsim_control.setBuildingAspectRatio(defaults[:aspect_ratio][:default])
+      end
+
+      # create the AirflowNetworkReferenceCrackConditions object that all other cracks reference
+      os_ref_crack = OpenStudio::Model::AirflowNetworkReferenceCrackConditions.new(openstudio_model)
+      os_ref_crack.setName('Reference Crack Conditions')
+
+      # assign the reference temperature
+      if @hash[:reference_temperature]
+        os_ref_crack.setTemperature(@hash[:reference_temperature])
+      else
+        os_ref_crack.setTemperature(defaults[:reference_temperature][:default])
+      end
+
+      # assign the reference pressure
+      if @hash[:reference_pressure]
+        os_ref_crack.setBarometricPressure(@hash[:reference_pressure])
+      else
+        os_ref_crack.setBarometricPressure(defaults[:reference_pressure][:default])
+      end
+
+      # assign the reference humidity ratio
+      if @hash[:reference_humidity_ratio]
+        os_ref_crack.setHumidityRatio(@hash[:reference_humidity_ratio])
+      else
+        os_ref_crack.setHumidityRatio(defaults[:reference_humidity_ratio][:default])
+      end
+
+      os_ref_crack
+    end
+
+  end #VentilationSimulationControl
+end #FromHoneybee

--- a/spec/samples/model/model_energy_afn.json
+++ b/spec/samples/model/model_energy_afn.json
@@ -1,0 +1,2180 @@
+{
+    "type": "Model",
+    "identifier": "Two_Zone_Simple",
+    "display_name": "Two_Zone_Simple",
+    "units": "Meters",
+    "properties": {
+        "type": "ModelProperties",
+        "energy": {
+            "type": "ModelEnergyProperties",
+            "construction_sets": [],
+            "constructions": [],
+            "materials": [],
+            "hvacs": [],
+            "program_types": [
+                {
+                    "type": "ProgramTypeAbridged",
+                    "identifier": "Generic Office Program",
+                    "people": {
+                        "type": "PeopleAbridged",
+                        "identifier": "Generic Office People",
+                        "people_per_area": 0.0565,
+                        "radiant_fraction": 0.3,
+                        "latent_fraction": {
+                            "type": "Autocalculate"
+                        },
+                        "occupancy_schedule": "Generic Office Occupancy",
+                        "activity_schedule": "Seated Adult Activity"
+                    },
+                    "lighting": {
+                        "type": "LightingAbridged",
+                        "identifier": "Generic Office Lighting",
+                        "watts_per_area": 10.55,
+                        "return_air_fraction": 0.0,
+                        "radiant_fraction": 0.7,
+                        "visible_fraction": 0.2,
+                        "schedule": "Generic Office Lighting"
+                    },
+                    "electric_equipment": {
+                        "type": "ElectricEquipmentAbridged",
+                        "identifier": "Generic Office Equipment",
+                        "watts_per_area": 10.33,
+                        "radiant_fraction": 0.5,
+                        "latent_fraction": 0.0,
+                        "lost_fraction": 0.0,
+                        "schedule": "Generic Office Equipment"
+                    },
+                    "infiltration": {
+                        "type": "InfiltrationAbridged",
+                        "identifier": "Generic Office Infiltration",
+                        "flow_per_exterior_area": 0.0002266,
+                        "schedule": "Generic Office Infiltration"
+                    },
+                    "ventilation": {
+                        "type": "VentilationAbridged",
+                        "identifier": "Generic Office Ventilation",
+                        "flow_per_person": 0.00236,
+                        "flow_per_area": 0.000305
+                    },
+                    "setpoint": {
+                        "type": "SetpointAbridged",
+                        "identifier": "Generic Office Setpoints",
+                        "heating_schedule": "Generic Office Heating",
+                        "cooling_schedule": "Generic Office Cooling"
+                    }
+                }
+            ],
+            "schedules": [
+                {
+                    "type": "ScheduleRulesetAbridged",
+                    "identifier": "Generic Office Lighting",
+                    "day_schedules": [
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_LIGHT_SCH_2013_Sun",
+                            "values": [
+                                0.05,
+                                0.04311628,
+                                0.05
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    18,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_LIGHT_SCH_2013_SmrDsn",
+                            "values": [
+                                1.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_LIGHT_SCH_2013_WntrDsn",
+                            "values": [
+                                0.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_LIGHT_SCH_2013_Sat",
+                            "values": [
+                                0.05,
+                                0.08623256,
+                                0.25869768,
+                                0.12934884,
+                                0.04311628,
+                                0.05
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    8,
+                                    0
+                                ],
+                                [
+                                    12,
+                                    0
+                                ],
+                                [
+                                    17,
+                                    0
+                                ],
+                                [
+                                    19,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_LIGHT_SCH_2013_Wkdy",
+                            "values": [
+                                0.05,
+                                0.1,
+                                0.08623256,
+                                0.25869768,
+                                0.77609304,
+                                0.4311628,
+                                0.25869768,
+                                0.17246512,
+                                0.08623256,
+                                0.04311628
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    5,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    7,
+                                    0
+                                ],
+                                [
+                                    8,
+                                    0
+                                ],
+                                [
+                                    17,
+                                    0
+                                ],
+                                [
+                                    18,
+                                    0
+                                ],
+                                [
+                                    20,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ],
+                                [
+                                    23,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        }
+                    ],
+                    "default_day_schedule": "OfficeMedium BLDG_LIGHT_SCH_2013_Sun",
+                    "schedule_rules": [
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium BLDG_LIGHT_SCH_2013_Wkdy",
+                            "apply_sunday": false,
+                            "apply_monday": true,
+                            "apply_tuesday": true,
+                            "apply_wednesday": true,
+                            "apply_thursday": true,
+                            "apply_friday": true,
+                            "apply_saturday": false,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        },
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium BLDG_LIGHT_SCH_2013_Sat",
+                            "apply_sunday": false,
+                            "apply_monday": false,
+                            "apply_tuesday": false,
+                            "apply_wednesday": false,
+                            "apply_thursday": false,
+                            "apply_friday": false,
+                            "apply_saturday": true,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        }
+                    ],
+                    "holiday_schedule": "OfficeMedium BLDG_LIGHT_SCH_2013_Sat",
+                    "summer_designday_schedule": "OfficeMedium BLDG_LIGHT_SCH_2013_SmrDsn",
+                    "winter_designday_schedule": "OfficeMedium BLDG_LIGHT_SCH_2013_WntrDsn",
+                    "schedule_type_limit": "Fractional"
+                },
+                {
+                    "type": "ScheduleRulesetAbridged",
+                    "identifier": "Always On",
+                    "day_schedules": [
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "Always On_Day Schedule",
+                            "values": [
+                                1.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        }
+                    ],
+                    "default_day_schedule": "Always On_Day Schedule",
+                    "schedule_type_limit": "Fractional"
+                },
+                {
+                    "type": "ScheduleRulesetAbridged",
+                    "identifier": "Generic Office Heating",
+                    "day_schedules": [
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Default",
+                            "values": [
+                                15.6
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Default_SmrDsn",
+                            "values": [
+                                15.6
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_WntrDsn",
+                            "values": [
+                                15.6,
+                                17.6,
+                                19.6,
+                                21.0,
+                                15.6
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    5,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    7,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Wkdy",
+                            "values": [
+                                15.6,
+                                17.8,
+                                20.0,
+                                21.0,
+                                15.6
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    5,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    7,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Sat",
+                            "values": [
+                                15.6,
+                                17.8,
+                                20.0,
+                                21.0,
+                                15.6
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    5,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    7,
+                                    0
+                                ],
+                                [
+                                    17,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        }
+                    ],
+                    "default_day_schedule": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Default",
+                    "schedule_rules": [
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Wkdy",
+                            "apply_sunday": false,
+                            "apply_monday": true,
+                            "apply_tuesday": true,
+                            "apply_wednesday": true,
+                            "apply_thursday": true,
+                            "apply_friday": true,
+                            "apply_saturday": false,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        },
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Sat",
+                            "apply_sunday": false,
+                            "apply_monday": false,
+                            "apply_tuesday": false,
+                            "apply_wednesday": false,
+                            "apply_thursday": false,
+                            "apply_friday": false,
+                            "apply_saturday": true,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        }
+                    ],
+                    "holiday_schedule": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Default",
+                    "summer_designday_schedule": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Default_SmrDsn",
+                    "winter_designday_schedule": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_WntrDsn",
+                    "schedule_type_limit": "Temperature"
+                },
+                {
+                    "type": "ScheduleRulesetAbridged",
+                    "identifier": "Generic Office Cooling",
+                    "day_schedules": [
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Default",
+                            "values": [
+                                26.7
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_SmrDsn",
+                            "values": [
+                                26.7,
+                                25.7,
+                                25.0,
+                                24.0,
+                                26.7
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    5,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    7,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Default_WntrDsn",
+                            "values": [
+                                26.7
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Wkdy",
+                            "values": [
+                                26.7,
+                                25.6,
+                                25.0,
+                                24.0,
+                                26.7
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    5,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    7,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Sat",
+                            "values": [
+                                26.7,
+                                25.7,
+                                25.0,
+                                24.0,
+                                26.7
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    5,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    7,
+                                    0
+                                ],
+                                [
+                                    17,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        }
+                    ],
+                    "default_day_schedule": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Default",
+                    "schedule_rules": [
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Wkdy",
+                            "apply_sunday": false,
+                            "apply_monday": true,
+                            "apply_tuesday": true,
+                            "apply_wednesday": true,
+                            "apply_thursday": true,
+                            "apply_friday": true,
+                            "apply_saturday": false,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        },
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Sat",
+                            "apply_sunday": false,
+                            "apply_monday": false,
+                            "apply_tuesday": false,
+                            "apply_wednesday": false,
+                            "apply_thursday": false,
+                            "apply_friday": false,
+                            "apply_saturday": true,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        }
+                    ],
+                    "holiday_schedule": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Default",
+                    "summer_designday_schedule": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_SmrDsn",
+                    "winter_designday_schedule": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Default_WntrDsn",
+                    "schedule_type_limit": "Temperature"
+                },
+                {
+                    "type": "ScheduleRulesetAbridged",
+                    "identifier": "House Heating",
+                    "day_schedules": [
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "House Heating_Day Schedule",
+                            "values": [
+                                20.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        }
+                    ],
+                    "default_day_schedule": "House Heating_Day Schedule",
+                    "schedule_type_limit": "Temperature"
+                },
+                {
+                    "type": "ScheduleRulesetAbridged",
+                    "identifier": "Generic Office Infiltration",
+                    "day_schedules": [
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium INFIL_SCH_PNNL_Default",
+                            "values": [
+                                1.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium INFIL_SCH_PNNL_Wkdy_SmrDsn",
+                            "values": [
+                                1.0,
+                                0.25,
+                                1.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium INFIL_SCH_PNNL_Sat_WntrDsn",
+                            "values": [
+                                1.0,
+                                0.25,
+                                1.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    18,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium INFIL_SCH_PNNL_Wkdy",
+                            "values": [
+                                1.0,
+                                0.25,
+                                1.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium INFIL_SCH_PNNL_Sat",
+                            "values": [
+                                1.0,
+                                0.25,
+                                1.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    18,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        }
+                    ],
+                    "default_day_schedule": "OfficeMedium INFIL_SCH_PNNL_Default",
+                    "schedule_rules": [
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium INFIL_SCH_PNNL_Wkdy",
+                            "apply_sunday": false,
+                            "apply_monday": true,
+                            "apply_tuesday": true,
+                            "apply_wednesday": true,
+                            "apply_thursday": true,
+                            "apply_friday": true,
+                            "apply_saturday": false,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        },
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium INFIL_SCH_PNNL_Sat",
+                            "apply_sunday": false,
+                            "apply_monday": false,
+                            "apply_tuesday": false,
+                            "apply_wednesday": false,
+                            "apply_thursday": false,
+                            "apply_friday": false,
+                            "apply_saturday": true,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        }
+                    ],
+                    "holiday_schedule": "OfficeMedium INFIL_SCH_PNNL_Default",
+                    "summer_designday_schedule": "OfficeMedium INFIL_SCH_PNNL_Wkdy_SmrDsn",
+                    "winter_designday_schedule": "OfficeMedium INFIL_SCH_PNNL_Sat_WntrDsn",
+                    "schedule_type_limit": "Fractional"
+                },
+                {
+                    "type": "ScheduleRulesetAbridged",
+                    "identifier": "Generic Office Occupancy",
+                    "day_schedules": [
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_OCC_SCH_Default",
+                            "values": [
+                                0.0,
+                                0.05,
+                                0.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    18,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_OCC_SCH_SmrDsn",
+                            "values": [
+                                0.0,
+                                1.0,
+                                0.05
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_OCC_SCH_WntrDsn",
+                            "values": [
+                                0.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_OCC_SCH_Wkdy",
+                            "values": [
+                                0.0,
+                                0.1,
+                                0.2,
+                                0.95,
+                                0.5,
+                                0.95,
+                                0.3,
+                                0.1,
+                                0.05
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    7,
+                                    0
+                                ],
+                                [
+                                    8,
+                                    0
+                                ],
+                                [
+                                    12,
+                                    0
+                                ],
+                                [
+                                    13,
+                                    0
+                                ],
+                                [
+                                    17,
+                                    0
+                                ],
+                                [
+                                    18,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_OCC_SCH_Sat",
+                            "values": [
+                                0.0,
+                                0.1,
+                                0.3,
+                                0.1,
+                                0.05,
+                                0.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    8,
+                                    0
+                                ],
+                                [
+                                    12,
+                                    0
+                                ],
+                                [
+                                    17,
+                                    0
+                                ],
+                                [
+                                    19,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        }
+                    ],
+                    "default_day_schedule": "OfficeMedium BLDG_OCC_SCH_Default",
+                    "schedule_rules": [
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium BLDG_OCC_SCH_Wkdy",
+                            "apply_sunday": false,
+                            "apply_monday": true,
+                            "apply_tuesday": true,
+                            "apply_wednesday": true,
+                            "apply_thursday": true,
+                            "apply_friday": true,
+                            "apply_saturday": false,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        },
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium BLDG_OCC_SCH_Sat",
+                            "apply_sunday": false,
+                            "apply_monday": false,
+                            "apply_tuesday": false,
+                            "apply_wednesday": false,
+                            "apply_thursday": false,
+                            "apply_friday": false,
+                            "apply_saturday": true,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        }
+                    ],
+                    "holiday_schedule": "OfficeMedium BLDG_OCC_SCH_Default",
+                    "summer_designday_schedule": "OfficeMedium BLDG_OCC_SCH_SmrDsn",
+                    "winter_designday_schedule": "OfficeMedium BLDG_OCC_SCH_WntrDsn",
+                    "schedule_type_limit": "Fractional"
+                },
+                {
+                    "type": "ScheduleRulesetAbridged",
+                    "identifier": "Generic Office Equipment",
+                    "day_schedules": [
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_EQUIP_SCH_2013_Sun",
+                            "values": [
+                                0.2307553806,
+                                0.288107175,
+                                0.2307553806
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    18,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_EQUIP_SCH_2013_SmrDsn",
+                            "values": [
+                                1.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_EQUIP_SCH_2013_WntrDsn",
+                            "values": [
+                                0.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_EQUIP_SCH_2013_Sat",
+                            "values": [
+                                0.2307553806,
+                                0.381234796,
+                                0.476543495,
+                                0.3335804465,
+                                0.285926097,
+                                0.2307553806
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    8,
+                                    0
+                                ],
+                                [
+                                    12,
+                                    0
+                                ],
+                                [
+                                    17,
+                                    0
+                                ],
+                                [
+                                    19,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_EQUIP_SCH_2013_Wkdy",
+                            "values": [
+                                0.3076738408,
+                                0.381234796,
+                                0.857778291,
+                                0.762469592,
+                                0.857778291,
+                                0.476543495,
+                                0.381234796
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    8,
+                                    0
+                                ],
+                                [
+                                    12,
+                                    0
+                                ],
+                                [
+                                    13,
+                                    0
+                                ],
+                                [
+                                    17,
+                                    0
+                                ],
+                                [
+                                    18,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        }
+                    ],
+                    "default_day_schedule": "OfficeMedium BLDG_EQUIP_SCH_2013_Sun",
+                    "schedule_rules": [
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium BLDG_EQUIP_SCH_2013_Wkdy",
+                            "apply_sunday": false,
+                            "apply_monday": true,
+                            "apply_tuesday": true,
+                            "apply_wednesday": true,
+                            "apply_thursday": true,
+                            "apply_friday": true,
+                            "apply_saturday": false,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        },
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium BLDG_EQUIP_SCH_2013_Sat",
+                            "apply_sunday": false,
+                            "apply_monday": false,
+                            "apply_tuesday": false,
+                            "apply_wednesday": false,
+                            "apply_thursday": false,
+                            "apply_friday": false,
+                            "apply_saturday": true,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        }
+                    ],
+                    "holiday_schedule": "OfficeMedium BLDG_EQUIP_SCH_2013_Sat",
+                    "summer_designday_schedule": "OfficeMedium BLDG_EQUIP_SCH_2013_SmrDsn",
+                    "winter_designday_schedule": "OfficeMedium BLDG_EQUIP_SCH_2013_WntrDsn",
+                    "schedule_type_limit": "Fractional"
+                },
+                {
+                    "type": "ScheduleRulesetAbridged",
+                    "identifier": "Seated Adult Activity",
+                    "day_schedules": [
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "Seated Adult Activity_Day Schedule",
+                            "values": [
+                                120.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        }
+                    ],
+                    "default_day_schedule": "Seated Adult Activity_Day Schedule",
+                    "schedule_type_limit": "Activity Level"
+                },
+                {
+                    "type": "ScheduleRulesetAbridged",
+                    "identifier": "House Cooling",
+                    "day_schedules": [
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "House Cooling_Day Schedule",
+                            "values": [
+                                28.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        }
+                    ],
+                    "default_day_schedule": "House Cooling_Day Schedule",
+                    "schedule_type_limit": "Temperature"
+                }
+            ],
+            "schedule_type_limits": [
+                {
+                    "type": "ScheduleTypeLimit",
+                    "identifier": "Activity Level",
+                    "lower_limit": 0.0,
+                    "upper_limit": {
+                        "type": "NoLimit"
+                    },
+                    "numeric_type": "Continuous",
+                    "unit_type": "ActivityLevel"
+                },
+                {
+                    "type": "ScheduleTypeLimit",
+                    "identifier": "Fractional",
+                    "lower_limit": 0.0,
+                    "upper_limit": 1.0,
+                    "numeric_type": "Continuous",
+                    "unit_type": "Dimensionless"
+                },
+                {
+                    "type": "ScheduleTypeLimit",
+                    "identifier": "Temperature",
+                    "lower_limit": -273.15,
+                    "upper_limit": {
+                        "type": "NoLimit"
+                    },
+                    "numeric_type": "Continuous",
+                    "unit_type": "Temperature"
+                }
+            ],
+            "ventilation_simulation_control": {
+                "type": "VentilationSimulationControl",
+                "vent_control_type": "MultiZoneWithoutDistribution",
+                "reference_temperature": 20.0,
+                "reference_pressure": 101325.0,
+                "reference_humidity_ratio": 0.0,
+                "building_type": "LowRise",
+                "long_axis_angle": 0.0,
+                "aspect_ratio": 1.0
+            }
+        }
+    },
+    "rooms": [
+        {
+            "type": "Room",
+            "identifier": "SouthRoom",
+            "display_name": "SouthRoom",
+            "properties": {
+                "type": "RoomPropertiesAbridged",
+                "energy": {
+                    "type": "RoomEnergyPropertiesAbridged",
+                    "program_type": "Generic Office Program",
+                    "setpoint": {
+                        "type": "SetpointAbridged",
+                        "identifier": "House Setpoint",
+                        "heating_schedule": "House Heating",
+                        "cooling_schedule": "House Cooling"
+                    },
+                    "window_vent_control": {
+                        "type": "VentilationControlAbridged",
+                        "min_indoor_temperature": 22.0,
+                        "max_indoor_temperature": 27.0,
+                        "min_outdoor_temperature": 12.0,
+                        "max_outdoor_temperature": 30.0,
+                        "delta_temperature": -100.0
+                    }
+                }
+            },
+            "faces": [
+                {
+                    "type": "Face",
+                    "identifier": "SouthRoom..Face0",
+                    "display_name": "SouthRoom..Face0",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                20.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                20.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                0.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Floor",
+                    "boundary_condition": {
+                        "type": "Ground"
+                    }
+                },
+                {
+                    "type": "Face",
+                    "identifier": "SouthRoom..Face1",
+                    "display_name": "SouthRoom..Face1",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged",
+                            "vent_crack": {
+                                "type": "AFNCrack",
+                                "flow_coefficient": 0.006648584928103797,
+                                "flow_exponent": 0.65
+                            }
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                20.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                20.0,
+                                0.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    }
+                },
+                {
+                    "type": "Face",
+                    "identifier": "SouthRoom..Face2",
+                    "display_name": "SouthRoom..Face2",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged",
+                            "vent_crack": {
+                                "type": "AFNCrack",
+                                "flow_coefficient": 0.0023270047248363287,
+                                "flow_exponent": 0.65
+                            }
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                20.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                20.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                20.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                20.0,
+                                10.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    },
+                    "apertures": [
+                        {
+                            "type": "Aperture",
+                            "identifier": "SouthRoom..Face2_Glz0",
+                            "display_name": "SouthRoom..Face2_Glz0",
+                            "properties": {
+                                "type": "AperturePropertiesAbridged",
+                                "energy": {
+                                    "type": "ApertureEnergyPropertiesAbridged",
+                                    "vent_opening": {
+                                        "type": "VentilationOpening",
+                                        "fraction_area_operable": 1.0,
+                                        "fraction_height_operable": 1.0,
+                                        "discharge_coefficient": 0.6,
+                                        "wind_cross_vent": false,
+                                        "flow_coefficient_closed": 7.003038347329447e-05,
+                                        "flow_exponent_closed": 0.667,
+                                        "two_way_threshold": 0.0001
+                                    }
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        20.0,
+                                        2.26138721247417,
+                                        2.3215838362577492
+                                    ],
+                                    [
+                                        20.0,
+                                        2.26138721247417,
+                                        0.6784161637422509
+                                    ],
+                                    [
+                                        20.0,
+                                        7.73861278752583,
+                                        0.6784161637422509
+                                    ],
+                                    [
+                                        20.0,
+                                        7.73861278752583,
+                                        2.3215838362577492
+                                    ]
+                                ]
+                            },
+                            "is_operable": true,
+                            "boundary_condition": {
+                                "type": "Outdoors",
+                                "sun_exposure": true,
+                                "wind_exposure": true,
+                                "view_factor": {
+                                    "type": "Autocalculate"
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Face",
+                    "identifier": "SouthRoom..Face3",
+                    "display_name": "SouthRoom..Face3",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged",
+                            "vent_crack": {
+                                "type": "AFNCrack",
+                                "flow_coefficient": 0.153,
+                                "flow_exponent": 0.75
+                            }
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                20.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                20.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Surface",
+                        "boundary_condition_objects": [
+                            "NorthRoom..Face1",
+                            "NorthRoom"
+                        ]
+                    },
+                    "apertures": [
+                        {
+                            "type": "Aperture",
+                            "identifier": "SouthRoom..Face3_Glz0",
+                            "display_name": "SouthRoom..Face3_Glz0",
+                            "properties": {
+                                "type": "AperturePropertiesAbridged",
+                                "energy": {
+                                    "type": "ApertureEnergyPropertiesAbridged",
+                                    "vent_opening": {
+                                        "type": "VentilationOpening",
+                                        "fraction_area_operable": 1.0,
+                                        "fraction_height_operable": 1.0,
+                                        "discharge_coefficient": 0.6,
+                                        "wind_cross_vent": false,
+                                        "flow_coefficient_closed": 0.0014,
+                                        "flow_exponent_closed": 0.65,
+                                        "two_way_threshold": 0.0001
+                                    }
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        13.872983346207416,
+                                        10.0,
+                                        2.0809475019311128
+                                    ],
+                                    [
+                                        13.872983346207416,
+                                        10.0,
+                                        0.9190524980688874
+                                    ],
+                                    [
+                                        6.127016653792583,
+                                        10.0,
+                                        0.9190524980688874
+                                    ],
+                                    [
+                                        6.127016653792583,
+                                        10.0,
+                                        2.0809475019311128
+                                    ]
+                                ]
+                            },
+                            "is_operable": true,
+                            "boundary_condition": {
+                                "type": "Surface",
+                                "boundary_condition_objects": [
+                                    "NorthRoom..Face1_Glz0",
+                                    "NorthRoom..Face1",
+                                    "NorthRoom"
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Face",
+                    "identifier": "SouthRoom..Face4",
+                    "display_name": "SouthRoom..Face4",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged",
+                            "vent_crack": {
+                                "type": "AFNCrack",
+                                "flow_coefficient": 0.0033242924640518984,
+                                "flow_exponent": 0.65
+                            }
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    }
+                },
+                {
+                    "type": "Face",
+                    "identifier": "SouthRoom..Face5",
+                    "display_name": "SouthRoom..Face5",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged",
+                            "vent_crack": {
+                                "type": "AFNCrack",
+                                "flow_coefficient": 0.022161949760345988,
+                                "flow_exponent": 0.65
+                            }
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                20.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                20.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "RoofCeiling",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "type": "Room",
+            "identifier": "NorthRoom",
+            "display_name": "NorthRoom",
+            "properties": {
+                "type": "RoomPropertiesAbridged",
+                "energy": {
+                    "type": "RoomEnergyPropertiesAbridged",
+                    "program_type": "Generic Office Program",
+                    "setpoint": {
+                        "type": "SetpointAbridged",
+                        "identifier": "House Setpoint",
+                        "heating_schedule": "House Heating",
+                        "cooling_schedule": "House Cooling"
+                    },
+                    "window_vent_control": {
+                        "type": "VentilationControlAbridged",
+                        "min_indoor_temperature": 22.0,
+                        "max_indoor_temperature": 27.0,
+                        "min_outdoor_temperature": 12.0,
+                        "max_outdoor_temperature": 30.0,
+                        "delta_temperature": -100.0
+                    }
+                }
+            },
+            "faces": [
+                {
+                    "type": "Face",
+                    "identifier": "NorthRoom..Face0",
+                    "display_name": "NorthRoom..Face0",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                20.0,
+                                0.0
+                            ],
+                            [
+                                20.0,
+                                20.0,
+                                0.0
+                            ],
+                            [
+                                20.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                0.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Floor",
+                    "boundary_condition": {
+                        "type": "Ground"
+                    }
+                },
+                {
+                    "type": "Face",
+                    "identifier": "NorthRoom..Face1",
+                    "display_name": "NorthRoom..Face1",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged",
+                            "vent_crack": {
+                                "type": "AFNCrack",
+                                "flow_coefficient": 0.153,
+                                "flow_exponent": 0.75
+                            }
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                20.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                20.0,
+                                10.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Surface",
+                        "boundary_condition_objects": [
+                            "SouthRoom..Face3",
+                            "SouthRoom"
+                        ]
+                    },
+                    "apertures": [
+                        {
+                            "type": "Aperture",
+                            "identifier": "NorthRoom..Face1_Glz0",
+                            "display_name": "NorthRoom..Face1_Glz0",
+                            "properties": {
+                                "type": "AperturePropertiesAbridged",
+                                "energy": {
+                                    "type": "ApertureEnergyPropertiesAbridged",
+                                    "vent_opening": {
+                                        "type": "VentilationOpening",
+                                        "fraction_area_operable": 1.0,
+                                        "fraction_height_operable": 1.0,
+                                        "discharge_coefficient": 0.6,
+                                        "wind_cross_vent": false,
+                                        "flow_coefficient_closed": 0.0014,
+                                        "flow_exponent_closed": 0.65,
+                                        "two_way_threshold": 0.0001
+                                    }
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        6.127016653792583,
+                                        10.0,
+                                        2.0809475019311128
+                                    ],
+                                    [
+                                        6.127016653792583,
+                                        10.0,
+                                        0.9190524980688874
+                                    ],
+                                    [
+                                        13.872983346207416,
+                                        10.0,
+                                        0.9190524980688874
+                                    ],
+                                    [
+                                        13.872983346207416,
+                                        10.0,
+                                        2.0809475019311128
+                                    ]
+                                ]
+                            },
+                            "is_operable": true,
+                            "boundary_condition": {
+                                "type": "Surface",
+                                "boundary_condition_objects": [
+                                    "SouthRoom..Face3_Glz0",
+                                    "SouthRoom..Face3",
+                                    "SouthRoom"
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Face",
+                    "identifier": "NorthRoom..Face2",
+                    "display_name": "NorthRoom..Face2",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged",
+                            "vent_crack": {
+                                "type": "AFNCrack",
+                                "flow_coefficient": 0.0033242924640518984,
+                                "flow_exponent": 0.65
+                            }
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                20.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                20.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                20.0,
+                                20.0,
+                                0.0
+                            ],
+                            [
+                                20.0,
+                                20.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    }
+                },
+                {
+                    "type": "Face",
+                    "identifier": "NorthRoom..Face3",
+                    "display_name": "NorthRoom..Face3",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged",
+                            "vent_crack": {
+                                "type": "AFNCrack",
+                                "flow_coefficient": 0.006648584928103797,
+                                "flow_exponent": 0.65
+                            }
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                20.0,
+                                20.0,
+                                3.0
+                            ],
+                            [
+                                20.0,
+                                20.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                20.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                20.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    }
+                },
+                {
+                    "type": "Face",
+                    "identifier": "NorthRoom..Face4",
+                    "display_name": "NorthRoom..Face4",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged",
+                            "vent_crack": {
+                                "type": "AFNCrack",
+                                "flow_coefficient": 0.0023270047248363287,
+                                "flow_exponent": 0.65
+                            }
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                20.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                20.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    },
+                    "apertures": [
+                        {
+                            "type": "Aperture",
+                            "identifier": "NorthRoom..Face4_Glz0",
+                            "display_name": "NorthRoom..Face4_Glz0",
+                            "properties": {
+                                "type": "AperturePropertiesAbridged",
+                                "energy": {
+                                    "type": "ApertureEnergyPropertiesAbridged",
+                                    "vent_opening": {
+                                        "type": "VentilationOpening",
+                                        "fraction_area_operable": 1.0,
+                                        "fraction_height_operable": 1.0,
+                                        "discharge_coefficient": 0.6,
+                                        "wind_cross_vent": false,
+                                        "flow_coefficient_closed": 7.003038347329447e-05,
+                                        "flow_exponent_closed": 0.667,
+                                        "two_way_threshold": 0.0001
+                                    }
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        0.0,
+                                        17.73861278752583,
+                                        2.3215838362577492
+                                    ],
+                                    [
+                                        0.0,
+                                        17.73861278752583,
+                                        0.6784161637422509
+                                    ],
+                                    [
+                                        0.0,
+                                        12.261387212474169,
+                                        0.6784161637422509
+                                    ],
+                                    [
+                                        0.0,
+                                        12.261387212474169,
+                                        2.3215838362577492
+                                    ]
+                                ]
+                            },
+                            "is_operable": true,
+                            "boundary_condition": {
+                                "type": "Outdoors",
+                                "sun_exposure": true,
+                                "wind_exposure": true,
+                                "view_factor": {
+                                    "type": "Autocalculate"
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Face",
+                    "identifier": "NorthRoom..Face5",
+                    "display_name": "NorthRoom..Face5",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged",
+                            "vent_crack": {
+                                "type": "AFNCrack",
+                                "flow_coefficient": 0.022161949760345988,
+                                "flow_exponent": 0.65
+                            }
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                20.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                20.0,
+                                20.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                20.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "RoofCeiling",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    }
+                }
+            ]
+        }
+    ],
+    "version": "1.33.1"
+}

--- a/spec/samples/ventcool/ventilation_crack.json
+++ b/spec/samples/ventcool/ventilation_crack.json
@@ -1,0 +1,5 @@
+{
+    "type": "AFNCrack",
+    "flow_coefficient": 0.01,
+    "flow_exponent": 0.65
+}

--- a/spec/samples/ventcool/ventilation_simulation_control.json
+++ b/spec/samples/ventcool/ventilation_simulation_control.json
@@ -1,0 +1,10 @@
+{
+    "type": "VentilationSimulationControl",
+    "vent_control_type": "MultiZoneWithoutDistribution",
+    "reference_temperature": 21.0,
+    "reference_pressure": 101325.0,
+    "reference_humidity_ratio": 0.5,
+    "building_type": "LowRise",
+    "long_axis_angle": 90.0,
+    "aspect_ratio": 0.5
+}

--- a/spec/tests/honeybee_model_spec.rb
+++ b/spec/tests/honeybee_model_spec.rb
@@ -101,6 +101,9 @@ RSpec.describe FromHoneybee do
     schedule_ruleset = openstudio_model.getScheduleRulesetByName('Generic Office Infiltration')
     expect(schedule_ruleset).not_to be nil
 
+    infilt = openstudio_model.getSpaceInfiltrationDesignFlowRates
+    expect(infilt.size).to be 1
+
   end
 
   it 'can load and validate shoebox model' do
@@ -231,6 +234,37 @@ RSpec.describe FromHoneybee do
     honeybee_obj_1 = FromHoneybee::Model.read_from_disk(file)
     object1 = honeybee_obj_1.to_openstudio_model(openstudio_model, log_report=false)
     expect(object1).not_to be nil
+
+    openstudio_vents = openstudio_model.getZoneVentilationWindandStackOpenAreas
+    expect(openstudio_vents.size).to be 2
+  end
+
+  it 'can load model with an Airflow Network' do
+    openstudio_model = OpenStudio::Model::Model.new
+    file = File.join(File.dirname(__FILE__), '../samples/model/model_energy_afn.json')
+    honeybee_obj_1 = FromHoneybee::Model.read_from_disk(file)
+    object1 = honeybee_obj_1.to_openstudio_model(openstudio_model, log_report=false)
+    expect(object1).not_to be nil
+
+    # make sure there are no single-zone ventilation objects in the model
+    infilt = openstudio_model.getSpaceInfiltrationDesignFlowRates
+    expect(infilt.size).to be 0
+    openstudio_vents = openstudio_model.getZoneVentilationWindandStackOpenAreas
+    expect(openstudio_vents.size).to be 0
+
+    # check to be sure the relevant AFN objects are there
+    openstudio_vents = openstudio_model.getAirflowNetworkSimpleOpenings
+    expect(openstudio_vents.size).to be 3
+    openstudio_cracks = openstudio_model.getAirflowNetworkCracks
+    expect(openstudio_cracks.size).to be 9
+    openstudio_cracks = openstudio_model.getEnergyManagementSystemSensors
+    expect(openstudio_cracks.size).to be 3
+    openstudio_cracks = openstudio_model.getEnergyManagementSystemActuators
+    expect(openstudio_cracks.size).to be 3
+    openstudio_cracks = openstudio_model.getEnergyManagementSystemPrograms
+    expect(openstudio_cracks.size).to be 2
+    openstudio_cracks = openstudio_model.getAirflowNetworkReferenceCrackConditionss
+    expect(openstudio_cracks.size).to be 1
   end
 
   it 'can triangulate 5vertex sub faces' do

--- a/spec/tests/honeybee_ventcool_spec.rb
+++ b/spec/tests/honeybee_ventcool_spec.rb
@@ -39,4 +39,14 @@ RSpec.describe FromHoneybee do
     honeybee_obj_1 = FromHoneybee::VentilationOpening.read_from_disk(file)
   end
 
+  it 'can load ventilation simulation control' do
+    openstudio_model = OpenStudio::Model::Model.new
+    file = File.join(File.dirname(__FILE__), '../samples/ventcool/ventilation_simulation_control.json')
+    honeybee_obj_1 = FromHoneybee::VentilationSimulationControl.read_from_disk(file)
+    object1 = honeybee_obj_1.to_openstudio(openstudio_model)
+    expect(object1).not_to be nil
+
+    expect(object1.nameString).to eq 'Reference Crack Conditions'
+  end
+
 end


### PR DESCRIPTION
This commit adds methods and classes to translate the AFN from honeybee-schema.

The global trigger to initialize the use of the AFN lies in the VentilationSimulationControl, which is processed first before the rest of the model is translated.  If the simulation control calls for anything other than "SingleZone", none of the simple zone ventilation, infiltration, or air mixing objects are added to the model.  Instead, the AFN is set up with the vent_crack objects on each Face being translated and any VentilationOpening objects are converted to AFN SimpleOpening objects.  Lastly, the VentilationControl objects assigned to each Room are translated to an EMS program instead of the usual WindAndStack object.

The gem is smart enough to recognize when adjacent surfaces already have their crack and VentilationOpening object translated so these only get written once.

@saeranv , I requested your review here so that you're aware of the update but you don't need to do a full review unless you want to.  I'll send you an IDF file generated from the gem, which will probably be a better way to QAQC.