### PR TITLE
fix(urbanopt): Update version of the gem used by URBANopt

### DIFF
--- a/lib/files/urbanopt_Gemfile
+++ b/lib/files/urbanopt_Gemfile
@@ -21,4 +21,4 @@ else
 end
 
 # include the honeybee-openstudio-gem
-gem 'honeybee-openstudio', '2.5.3'
+gem 'honeybee-openstudio', '2.6.4'


### PR DESCRIPTION
All of the features currently in the gem are compatible with the latest URBANopt so I'm updating it.