### PR TITLE
feat(openstudio): Upgrade for compatibility with OpenStudio 3.1.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,9 @@ jobs:
         run:
           npm install @semantic-release/exec
       - name: run semantic release
-        run:
+        run: |
+          git config --global user.email "releases@ladybug.tools"
+          git config --global user.name "ladybugbot"
           npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/lib/to_openstudio/construction/air.rb
+++ b/lib/to_openstudio/construction/air.rb
@@ -46,12 +46,7 @@ module Honeybee
       os_construction = OpenStudio::Model::ConstructionAirBoundary.new(openstudio_model)
       os_construction.setName(@hash[:identifier])
       os_construction.setSolarAndDaylightingMethod('GroupedZones')
-      # REMOVE: Remove the use of IRTSurface once the AFN works with GroupedZone air walls
-      if !$use_simple_vent  # we're using the AFN!
-        os_construction.setRadiantExchangeMethod('IRTSurface')
-      else
-        os_construction.setRadiantExchangeMethod('GroupedZones')
-      end
+      os_construction.setRadiantExchangeMethod('GroupedZones')
       os_construction.setAirExchangeMethod('None')
 
       os_construction

--- a/lib/to_openstudio/hvac/template.rb
+++ b/lib/to_openstudio/hvac/template.rb
@@ -84,14 +84,6 @@ module Honeybee
         end
       end
 
-      # TODO: consider adding the ability to decentralize the plant by changing loop names
-      #os_hvac.each do |hvac_loop|
-      #  loop_name = hvac_loop.name
-      #  unless loop_name.empty?
-      #    hvac_loop.setName(@hash[:identifier] + ' - ' + loop_name.get)
-      #  end
-      #end
-
       # assign the economizer type if there's an air loop and the economizer is specified
       if @hash[:economizer_type] && @hash[:economizer_type] != 'Inferred' && os_air_loop
         oasys = os_air_loop.airLoopHVACOutdoorAirSystem
@@ -126,6 +118,12 @@ module Honeybee
         erv.setLatentEffectivenessat100HeatingAirFlow(eff_at_max)
         erv.setLatentEffectivenessat75CoolingAirFlow(@hash[:latent_heat_recovery])
         erv.setLatentEffectivenessat75HeatingAirFlow(@hash[:latent_heat_recovery])
+      end
+
+      # set all plants to non-coincident sizing to avoid simualtion control on design days
+      openstudio_model.getPlantLoops.each do |loop|
+        sizing = loop.sizingPlant
+        sizing.setSizingOption('NonCoincident')
       end
 
       os_hvac

--- a/lib/to_openstudio/schedule/ruleset.rb
+++ b/lib/to_openstudio/schedule/ruleset.rb
@@ -85,10 +85,7 @@ module Honeybee
         holiday_schedule = openstudio_model.getScheduleDayByName(@hash[:holiday_schedule])
         unless holiday_schedule.empty?
           holiday_schedule_object = holiday_schedule.get
-          begin
-            os_sch_ruleset.setHolidaySchedule(holiday_schedule_object)
-          rescue NoMethodError  # REMOVE: Once the upgrade to OpenStudio 3.0 is official
-          end
+          os_sch_ruleset.setHolidaySchedule(holiday_schedule_object)
         end
       end
 

--- a/lib/to_openstudio/simulation/parameter_model.rb
+++ b/lib/to_openstudio/simulation/parameter_model.rb
@@ -98,54 +98,28 @@ module Honeybee
 
       # set defaults for the Model's ShadowCalculation object
       os_shadow_calc = @openstudio_model.getShadowCalculation
-      begin
-        os_shadow_calc.setShadingCalculationMethod(
-          shdw_defaults[:calculation_method][:default])
-      rescue NoMethodError  # REMOVE: Once the upgrade to OpenStudio 3.0 is official
-        os_shadow_calc.setCalculationMethod(
-          shdw_defaults[:calculation_method][:default])
-      end
-      begin
-        os_shadow_calc.setShadingCalculationUpdateFrequencyMethod(
-          shdw_defaults[:calculation_update_method][:default])
-      rescue  # REMOVE: Once the upgrade to OpenStudio 3.0 is official
-      end
-      begin
-        os_shadow_calc.setShadingCalculationUpdateFrequency(
-          shdw_defaults[:calculation_frequency][:default])
-      rescue NoMethodError  # REMOVE: Once the upgrade to OpenStudio 3.0 is official
-        os_shadow_calc.setCalculationFrequency(
-          shdw_defaults[:calculation_frequency][:default])
-      end
+      os_shadow_calc.setShadingCalculationMethod(
+        shdw_defaults[:calculation_method][:default])
+      os_shadow_calc.setShadingCalculationUpdateFrequencyMethod(
+        shdw_defaults[:calculation_update_method][:default])
+      os_shadow_calc.setShadingCalculationUpdateFrequency(
+        shdw_defaults[:calculation_frequency][:default])
       os_shadow_calc.setMaximumFiguresInShadowOverlapCalculations(
         shdw_defaults[:maximum_figures][:default])
 
       # override any ShadowCalculation defaults with lodaded JSON
       if @hash[:shadow_calculation]
         if @hash[:shadow_calculation][:calculation_method]
-          begin
-            os_shadow_calc.setShadingCalculationMethod(
-              @hash[:shadow_calculation][:calculation_method])
-          rescue NoMethodError  # REMOVE: Once the upgrade to OpenStudio 3.0 is official
-            os_shadow_calc.setCalculationMethod(
-              @hash[:shadow_calculation][:calculation_method])
-          end
+          os_shadow_calc.setShadingCalculationMethod(
+            @hash[:shadow_calculation][:calculation_method])
         end
         if @hash[:shadow_calculation][:calculation_update_method]
-          begin
-            os_shadow_calc.setShadingCalculationUpdateFrequencyMethod(
-              @hash[:shadow_calculation][:calculation_update_method])
-          rescue  # REMOVE: Once the upgrade to OpenStudio 3.0 is official
-          end
+          os_shadow_calc.setShadingCalculationUpdateFrequencyMethod(
+            @hash[:shadow_calculation][:calculation_update_method])
         end
         if @hash[:shadow_calculation][:calculation_frequency]
-          begin
-            os_shadow_calc.setShadingCalculationUpdateFrequency(
-              @hash[:shadow_calculation][:calculation_frequency])
-          rescue NoMethodError  # REMOVE: Once the upgrade to OpenStudio 3.0 is official
-            os_shadow_calc.setCalculationFrequency(
-              @hash[:shadow_calculation][:calculation_frequency])
-          end
+          os_shadow_calc.setShadingCalculationUpdateFrequency(
+            @hash[:shadow_calculation][:calculation_frequency])
         end
         if @hash[:shadow_calculation][:maximum_figures]
           os_shadow_calc.setMaximumFiguresInShadowOverlapCalculations(
@@ -192,15 +166,9 @@ module Honeybee
           end
         end
         if @hash[:output][:summary_reports]
-          begin
-            os_report = @openstudio_model.getOutputTableSummaryReports
-          rescue  # REMOVE: Once the upgrade to OpenStudio 3.0 is official
-          end
+          os_report = @openstudio_model.getOutputTableSummaryReports
           @hash[:output][:summary_reports].each do |report|
-            begin
-              os_report.addSummaryReport(report)
-            rescue NoMethodError  # REMOVE: Once the upgrade to OpenStudio 3.0 is official
-            end
+            os_report.addSummaryReport(report)
           end
         end
       end
@@ -242,13 +210,10 @@ module Honeybee
         # Set the holidays
         if @hash[:run_period][:holidays]
           @hash[:run_period][:holidays].each do |hol|
-            begin
-              os_hol = OpenStudio::Model::RunPeriodControlSpecialDays.new(
-                OpenStudio::MonthOfYear.new(hol[0]), hol[1], @openstudio_model)
-              os_hol.setDuration(1)
-              os_hol.setSpecialDayType('Holiday')
-            rescue NoMethodError  # REMOVE: Once the upgrade to OpenStudio 3.0 is official
-            end
+            os_hol = OpenStudio::Model::RunPeriodControlSpecialDays.new(
+              OpenStudio::MonthOfYear.new(hol[0]), hol[1], @openstudio_model)
+            os_hol.setDuration(1)
+            os_hol.setSpecialDayType('Holiday')
           end
         end
       end


### PR DESCRIPTION
The changes here include the cleaning up of "bridge" code that was just to run the measure in OpenStudio 2.9.1 (back when we were first developing it).

Now that the E+ AFN can work with the ConstructionAirBoundary, I also removed the hack to get it to work (with IR transparent surface).

Resolves https://github.com/ladybug-tools/honeybee-openstudio-gem/issues/117