### PR TITLE
fix(hvac): Ensure humidistat is used with Ideal Air if specified

### DIFF
--- a/lib/to_openstudio/model.rb
+++ b/lib/to_openstudio/model.rb
@@ -451,6 +451,12 @@ module Honeybee
               unless zone_get.empty?
                 os_thermal_zone = zone_get.get
                 os_ideal_air.addToThermalZone(os_thermal_zone)
+                # set the humidistat if the zone has one
+                humid_get = os_thermal_zone.zoneControlHumidistat
+                unless humid_get.empty?
+                  os_ideal_air.setDehumidificationControlType('Humidistat')
+                  os_ideal_air.setHumidificationControlType('Humidistat')
+                end
               end
             end
           elsif TemplateHVAC.types.include?(system_type)


### PR DESCRIPTION
For the other HVAC templates, we'll probably have to add extra pieces of equipment in order to be able to account for humidification. But this at least ensures expected behavior for the Ideal Air template.