### PR TITLE
fix(hvac): Ensure that the correct air loop is pulled

### DIFF
--- a/lib/honeybee/model_object.rb
+++ b/lib/honeybee/model_object.rb
@@ -100,7 +100,7 @@ module Honeybee
 
     # remove illegal characters in identifier
     def self.clean_identifier(str)
-      str.gsub(' ', '_')
+      str.gsub(/[^.A-Za-z0-9_-] /, '_')
     end
 
 

--- a/lib/to_openstudio/hvac/template.rb
+++ b/lib/to_openstudio/hvac/template.rb
@@ -83,11 +83,19 @@ module Honeybee
       air_loops = openstudio_model.getAirLoopHVACs
       unless air_loops.length == $air_loop_count  # check if any new loops were added
         $air_loop_count = air_loops.length
-        os_air_loop = air_loops[-1]
-        loop_name = os_air_loop.name
-        unless loop_name.empty?
-          if @hash[:display_name]
-            os_air_loop.setName(@hash[:display_name] + ' - ' + loop_name.get)
+        os_air_terminal = zones[0].airLoopHVACTerminal
+        unless os_air_terminal.empty?
+          os_air_terminal = os_air_terminal.get
+          os_air_loop_opt = os_air_terminal.airLoopHVAC
+          unless os_air_loop_opt.empty?
+            os_air_loop = os_air_loop_opt.get
+            loop_name = os_air_loop.name
+            unless loop_name.empty?
+              if @hash[:display_name]
+                clean_name = @hash[:display_name].to_s.gsub(/[^.A-Za-z0-9_-] /, " ")
+                os_air_loop.setName(clean_name + ' - ' + loop_name.get)
+              end
+            end
           end
         end
       end


### PR DESCRIPTION
It seems that the order of objects returned by the OpenStudio getXXX method is not consistent. This fix ensures that we pull the air loop from the zones instead of this method.

I am also adding a small fix to the method that cleans the IDs of geometry so that they are safe for Radiance.

Resolves https://github.com/ladybug-tools/honeybee-openstudio-gem/issues/192
Resolves https://github.com/ladybug-tools/honeybee-openstudio-gem/issues/180