### PR TITLE
fix(construction): Change construction schema to be more consistent

### DIFF
--- a/lib/honeybee/_defaults/energy_default.json
+++ b/lib/honeybee/_defaults/energy_default.json
@@ -45,14 +45,14 @@
         {
             "type": "OpaqueConstructionAbridged",
             "identifier": "Generic Interior Door",
-            "layers": [
+            "materials": [
                 "Generic 25mm Wood"
             ]
         },
         {
             "type": "WindowConstructionAbridged",
             "identifier": "Generic Single Pane",
-            "layers": [
+            "materials": [
                 "Generic Clear Glass"
             ]
         },
@@ -73,7 +73,7 @@
         {
             "type": "OpaqueConstructionAbridged",
             "identifier": "Generic Interior Ceiling",
-            "layers": [
+            "materials": [
                 "Generic LW Concrete",
                 "Generic Ceiling Air Gap",
                 "Generic Acoustic Tile"
@@ -82,7 +82,7 @@
         {
             "type": "OpaqueConstructionAbridged",
             "identifier": "Generic Interior Wall",
-            "layers": [
+            "materials": [
                 "Generic Gypsum Board",
                 "Generic Wall Air Gap",
                 "Generic Gypsum Board"
@@ -91,7 +91,7 @@
         {
             "type": "OpaqueConstructionAbridged",
             "identifier": "Generic Exposed Floor",
-            "layers": [
+            "materials": [
                 "Generic Painted Metal",
                 "Generic Ceiling Air Gap",
                 "Generic 50mm Insulation",
@@ -101,7 +101,7 @@
         {
             "type": "OpaqueConstructionAbridged",
             "identifier": "Generic Interior Floor",
-            "layers": [
+            "materials": [
                 "Generic Acoustic Tile",
                 "Generic Ceiling Air Gap",
                 "Generic LW Concrete"
@@ -110,7 +110,7 @@
         {
             "type": "OpaqueConstructionAbridged",
             "identifier": "Generic Ground Slab",
-            "layers": [
+            "materials": [
                 "Generic 50mm Insulation",
                 "Generic HW Concrete"
             ]
@@ -118,7 +118,7 @@
         {
             "type": "OpaqueConstructionAbridged",
             "identifier": "Generic Roof",
-            "layers": [
+            "materials": [
                 "Generic Roof Membrane",
                 "Generic 50mm Insulation",
                 "Generic LW Concrete",
@@ -129,7 +129,7 @@
         {
             "type": "OpaqueConstructionAbridged",
             "identifier": "Generic Exterior Wall",
-            "layers": [
+            "materials": [
                 "Generic Brick",
                 "Generic LW Concrete",
                 "Generic 50mm Insulation",
@@ -140,7 +140,7 @@
         {
             "type": "OpaqueConstructionAbridged",
             "identifier": "Generic Underground Wall",
-            "layers": [
+            "materials": [
                 "Generic 50mm Insulation",
                 "Generic HW Concrete",
                 "Generic Wall Air Gap",
@@ -156,7 +156,7 @@
         {
             "type": "OpaqueConstructionAbridged",
             "identifier": "Generic Underground Roof",
-            "layers": [
+            "materials": [
                 "Generic 50mm Insulation",
                 "Generic HW Concrete",
                 "Generic Ceiling Air Gap",
@@ -166,7 +166,7 @@
         {
             "type": "WindowConstructionAbridged",
             "identifier": "Generic Double Pane",
-            "layers": [
+            "materials": [
                 "Generic Low-e Glass",
                 "Generic Window Air Gap",
                 "Generic Clear Glass"
@@ -175,7 +175,7 @@
         {
             "type": "OpaqueConstructionAbridged",
             "identifier": "Generic Exterior Door",
-            "layers": [
+            "materials": [
                 "Generic Painted Metal",
                 "Generic 25mm Insulation",
                 "Generic Painted Metal"

--- a/lib/honeybee/_defaults/model.json
+++ b/lib/honeybee/_defaults/model.json
@@ -3,7 +3,7 @@
   "servers": [],
   "info": {
     "description": "Honeybee model schema.",
-    "version": "1.43.0",
+    "version": "1.43.1",
     "title": "Honeybee Model Schema",
     "contact": {
       "name": "Ladybug Tools",
@@ -3699,21 +3699,9 @@
             "minLength": 1,
             "type": "string"
           },
-          "layers": {
-            "title": "Layers",
-            "description": "List of strings for opaque material identifiers. The order of the materials is from exterior to interior.",
-            "minItems": 1,
-            "maxItems": 10,
-            "type": "array",
-            "items": {
-              "type": "string",
-              "minLength": 1,
-              "maxLength": 100
-            }
-          },
           "materials": {
             "title": "Materials",
-            "description": "List of opaque material definitions that are referenced in the layers. Note that the order of materials does not matter and there is no need to specify duplicated materials in this list.",
+            "description": "List of opaque material definitions. The order of the materials is from exterior to interior.",
             "minItems": 1,
             "maxItems": 10,
             "type": "array",
@@ -3743,7 +3731,6 @@
         },
         "required": [
           "identifier",
-          "layers",
           "materials"
         ],
         "additionalProperties": false
@@ -4316,21 +4303,9 @@
             "minLength": 1,
             "type": "string"
           },
-          "layers": {
-            "title": "Layers",
-            "description": "List of strings for glazing or gas material identifiers. The order of the materials is from exterior to interior. If a SimpleGlazSys material is used, it must be the only material in the construction. For multi-layered constructions, adjacent glass layers must be separated by one and only one gas layer.",
-            "minItems": 1,
-            "maxItems": 8,
-            "type": "array",
-            "items": {
-              "type": "string",
-              "minLength": 1,
-              "maxLength": 100
-            }
-          },
           "materials": {
             "title": "Materials",
-            "description": "List of glazing and gas material definitions that are referenced in the layers. Note that the order of materials does not matter and there is no need to specify duplicated materials in this list.",
+            "description": "List of glazing and gas material definitions. The order of the materials is from exterior to interior. If a SimpleGlazSys material is used, it must be the only material in the construction. For multi-layered constructions, adjacent glass layers must be separated by one and only one gas layer.",
             "minItems": 1,
             "maxItems": 8,
             "type": "array",
@@ -4369,7 +4344,6 @@
         },
         "required": [
           "identifier",
-          "layers",
           "materials"
         ],
         "additionalProperties": false
@@ -5150,8 +5124,8 @@
             "minLength": 1,
             "type": "string"
           },
-          "layers": {
-            "title": "Layers",
+          "materials": {
+            "title": "Materials",
             "description": "List of strings for opaque material identifiers. The order of the materials is from exterior to interior.",
             "minItems": 1,
             "maxItems": 10,
@@ -5177,7 +5151,7 @@
         },
         "required": [
           "identifier",
-          "layers"
+          "materials"
         ],
         "additionalProperties": false
       },
@@ -5193,8 +5167,8 @@
             "minLength": 1,
             "type": "string"
           },
-          "layers": {
-            "title": "Layers",
+          "materials": {
+            "title": "Materials",
             "description": "List of strings for glazing or gas material identifiers. The order of the materials is from exterior to interior. If a SimpleGlazSys material is used, it must be the only material in the construction. For multi-layered constructions, adjacent glass layers must be separated by one and only one gas layer.",
             "minItems": 1,
             "maxItems": 8,
@@ -5220,7 +5194,7 @@
         },
         "required": [
           "identifier",
-          "layers"
+          "materials"
         ],
         "additionalProperties": false
       },
@@ -11365,7 +11339,7 @@
           "version": {
             "title": "Version",
             "description": "Text string for the current version of the schema.",
-            "default": "1.43.0",
+            "default": "1.43.1",
             "pattern": "([0-9]+)\\.([0-9]+)\\.([0-9]+)",
             "type": "string",
             "readOnly": true

--- a/lib/to_openstudio/construction/opaque.rb
+++ b/lib/to_openstudio/construction/opaque.rb
@@ -50,8 +50,12 @@ module Honeybee
       # create material vector
       os_materials = OpenStudio::Model::MaterialVector.new
       # loop through each layer and add to material vector
-      @hash[:layers].each do |layer|
-        material_identifier = layer
+      if @hash.key?(:layers)
+        mat_key = :layers
+      else
+        mat_key = :materials
+      end
+      @hash[mat_key].each do |material_identifier|
         material = openstudio_model.getMaterialByName(material_identifier)
         unless material.empty?
           os_material = material.get

--- a/lib/to_openstudio/construction/window.rb
+++ b/lib/to_openstudio/construction/window.rb
@@ -50,8 +50,12 @@ module Honeybee
       # create material vector
       os_materials = OpenStudio::Model::MaterialVector.new
       # loop through each layer and add to material vector
-      @hash[:layers].each do |layer|
-        material_identifier = layer
+      if @hash.key?(:layers)
+        mat_key = :layers
+      else
+        mat_key = :materials
+      end
+      @hash[mat_key].each do |material_identifier|
         material = openstudio_model.getMaterialByName(material_identifier)
         unless material.empty?
           os_material = material.get

--- a/lib/to_openstudio/construction/windowshade.rb
+++ b/lib/to_openstudio/construction/windowshade.rb
@@ -62,8 +62,12 @@ module Honeybee
 
       # create the layers of the unshaded construction into which we will insert the shade
       os_materials = []
-      @hash[:window_construction][:layers].each do |layer|
-        material_identifier = layer
+      if @hash.key?(:layers)
+        mat_key = :layers
+      else
+        mat_key = :materials
+      end
+      @hash[:window_construction][mat_key].each do |material_identifier|
         material = openstudio_model.getMaterialByName(material_identifier)
         unless material.empty?
           os_material = material.get

--- a/spec/samples/construction/construction_opaque_door.json
+++ b/spec/samples/construction/construction_opaque_door.json
@@ -1,7 +1,7 @@
 {
     "type": "OpaqueConstructionAbridged",
     "identifier": "Generic Exterior Door",
-    "layers": [
+    "materials": [
         "Generic Painted Metal",
         "Generic 25mm Insulation",
         "Generic Painted Metal"

--- a/spec/samples/construction/construction_opaque_roof.json
+++ b/spec/samples/construction/construction_opaque_roof.json
@@ -1,7 +1,7 @@
 {
     "type": "OpaqueConstructionAbridged",
     "identifier": "Generic Roof",
-    "layers": [
+    "materials": [
         "Generic Roof Membrane",
         "Generic 50mm Insulation",
         "Generic LW Concrete",

--- a/spec/samples/construction/construction_opaque_wall.json
+++ b/spec/samples/construction/construction_opaque_wall.json
@@ -1,7 +1,7 @@
 {
     "type": "OpaqueConstructionAbridged",
     "identifier": "Generic Exterior Wall",
-    "layers": [
+    "materials": [
         "Generic Brick",
         "Generic LW Concrete",
         "Generic 50mm Insulation",

--- a/spec/samples/construction/construction_window_blinds.json
+++ b/spec/samples/construction/construction_window_blinds.json
@@ -4,7 +4,7 @@
     "window_construction": {
         "type": "WindowConstructionAbridged",
         "identifier": "Double Low-E",
-        "layers": [
+        "materials": [
             "Generic Low-e Glass",
             "Generic Window Argon Gap",
             "Generic Clear Glass"

--- a/spec/samples/construction/construction_window_double.json
+++ b/spec/samples/construction/construction_window_double.json
@@ -1,7 +1,7 @@
 {
     "type": "WindowConstructionAbridged",
     "identifier": "Generic Double Pane",
-    "layers": [
+    "materials": [
         "Generic Low-e Glass",
         "Generic Window Air Gap",
         "Generic Clear Glass"

--- a/spec/samples/construction/construction_window_shade.json
+++ b/spec/samples/construction/construction_window_shade.json
@@ -4,7 +4,7 @@
     "window_construction": {
         "type": "WindowConstructionAbridged",
         "identifier": "Double Low-E",
-        "layers": [
+        "materials": [
             "Generic Low-e Glass",
             "Generic Window Argon Gap",
             "Generic Clear Glass"

--- a/spec/samples/construction/construction_window_triple.json
+++ b/spec/samples/construction/construction_window_triple.json
@@ -1,7 +1,7 @@
 {
     "type": "WindowConstructionAbridged",
     "identifier": "Triple Pane Argon",
-    "layers": [
+    "materials": [
         "Generic Low-e Glass",
         "Generic Window Argon Gap",
         "Generic Low-e Glass",

--- a/spec/samples/construction_set/constructionset_complete.json
+++ b/spec/samples/construction_set/constructionset_complete.json
@@ -6,26 +6,7 @@
         "exterior_construction": {
             "type": "OpaqueConstruction",
             "identifier": "Generic Exterior Wall",
-            "layers": [
-                "Generic Brick",
-                "Generic LW Concrete",
-                "Generic 50mm Insulation",
-                "Generic Wall Air Gap",
-                "Generic Gypsum Board"
-            ],
             "materials": [
-                {
-                    "type": "EnergyMaterial",
-                    "identifier": "Generic 50mm Insulation",
-                    "roughness": "MediumRough",
-                    "thickness": 0.05,
-                    "conductivity": 0.03,
-                    "density": 43.0,
-                    "specific_heat": 1210.0,
-                    "thermal_absorptance": 0.9,
-                    "solar_absorptance": 0.7,
-                    "visible_absorptance": 0.7
-                },
                 {
                     "type": "EnergyMaterial",
                     "identifier": "Generic Brick",
@@ -40,18 +21,6 @@
                 },
                 {
                     "type": "EnergyMaterial",
-                    "identifier": "Generic Wall Air Gap",
-                    "roughness": "Smooth",
-                    "thickness": 0.1,
-                    "conductivity": 0.667,
-                    "density": 1.28,
-                    "specific_heat": 1000.0,
-                    "thermal_absorptance": 0.9,
-                    "solar_absorptance": 0.7,
-                    "visible_absorptance": 0.7
-                },
-                {
-                    "type": "EnergyMaterial",
                     "identifier": "Generic LW Concrete",
                     "roughness": "MediumRough",
                     "thickness": 0.1,
@@ -61,6 +30,30 @@
                     "thermal_absorptance": 0.9,
                     "solar_absorptance": 0.8,
                     "visible_absorptance": 0.8
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic 50mm Insulation",
+                    "roughness": "MediumRough",
+                    "thickness": 0.05,
+                    "conductivity": 0.03,
+                    "density": 43.0,
+                    "specific_heat": 1210.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.7,
+                    "visible_absorptance": 0.7
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic Wall Air Gap",
+                    "roughness": "Smooth",
+                    "thickness": 0.1,
+                    "conductivity": 0.667,
+                    "density": 1.28,
+                    "specific_heat": 1000.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.7,
+                    "visible_absorptance": 0.7
                 },
                 {
                     "type": "EnergyMaterial",
@@ -79,26 +72,7 @@
         "interior_construction": {
             "type": "OpaqueConstruction",
             "identifier": "Generic Exterior Wall",
-            "layers": [
-                "Generic Brick",
-                "Generic LW Concrete",
-                "Generic 50mm Insulation",
-                "Generic Wall Air Gap",
-                "Generic Gypsum Board"
-            ],
             "materials": [
-                {
-                    "type": "EnergyMaterial",
-                    "identifier": "Generic 50mm Insulation",
-                    "roughness": "MediumRough",
-                    "thickness": 0.05,
-                    "conductivity": 0.03,
-                    "density": 43.0,
-                    "specific_heat": 1210.0,
-                    "thermal_absorptance": 0.9,
-                    "solar_absorptance": 0.7,
-                    "visible_absorptance": 0.7
-                },
                 {
                     "type": "EnergyMaterial",
                     "identifier": "Generic Brick",
@@ -113,18 +87,6 @@
                 },
                 {
                     "type": "EnergyMaterial",
-                    "identifier": "Generic Wall Air Gap",
-                    "roughness": "Smooth",
-                    "thickness": 0.1,
-                    "conductivity": 0.667,
-                    "density": 1.28,
-                    "specific_heat": 1000.0,
-                    "thermal_absorptance": 0.9,
-                    "solar_absorptance": 0.7,
-                    "visible_absorptance": 0.7
-                },
-                {
-                    "type": "EnergyMaterial",
                     "identifier": "Generic LW Concrete",
                     "roughness": "MediumRough",
                     "thickness": 0.1,
@@ -134,6 +96,30 @@
                     "thermal_absorptance": 0.9,
                     "solar_absorptance": 0.8,
                     "visible_absorptance": 0.8
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic 50mm Insulation",
+                    "roughness": "MediumRough",
+                    "thickness": 0.05,
+                    "conductivity": 0.03,
+                    "density": 43.0,
+                    "specific_heat": 1210.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.7,
+                    "visible_absorptance": 0.7
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic Wall Air Gap",
+                    "roughness": "Smooth",
+                    "thickness": 0.1,
+                    "conductivity": 0.667,
+                    "density": 1.28,
+                    "specific_heat": 1000.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.7,
+                    "visible_absorptance": 0.7
                 },
                 {
                     "type": "EnergyMaterial",
@@ -152,26 +138,7 @@
         "ground_construction": {
             "type": "OpaqueConstruction",
             "identifier": "Generic Exterior Wall",
-            "layers": [
-                "Generic Brick",
-                "Generic LW Concrete",
-                "Generic 50mm Insulation",
-                "Generic Wall Air Gap",
-                "Generic Gypsum Board"
-            ],
             "materials": [
-                {
-                    "type": "EnergyMaterial",
-                    "identifier": "Generic 50mm Insulation",
-                    "roughness": "MediumRough",
-                    "thickness": 0.05,
-                    "conductivity": 0.03,
-                    "density": 43.0,
-                    "specific_heat": 1210.0,
-                    "thermal_absorptance": 0.9,
-                    "solar_absorptance": 0.7,
-                    "visible_absorptance": 0.7
-                },
                 {
                     "type": "EnergyMaterial",
                     "identifier": "Generic Brick",
@@ -186,18 +153,6 @@
                 },
                 {
                     "type": "EnergyMaterial",
-                    "identifier": "Generic Wall Air Gap",
-                    "roughness": "Smooth",
-                    "thickness": 0.1,
-                    "conductivity": 0.667,
-                    "density": 1.28,
-                    "specific_heat": 1000.0,
-                    "thermal_absorptance": 0.9,
-                    "solar_absorptance": 0.7,
-                    "visible_absorptance": 0.7
-                },
-                {
-                    "type": "EnergyMaterial",
                     "identifier": "Generic LW Concrete",
                     "roughness": "MediumRough",
                     "thickness": 0.1,
@@ -207,6 +162,30 @@
                     "thermal_absorptance": 0.9,
                     "solar_absorptance": 0.8,
                     "visible_absorptance": 0.8
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic 50mm Insulation",
+                    "roughness": "MediumRough",
+                    "thickness": 0.05,
+                    "conductivity": 0.03,
+                    "density": 43.0,
+                    "specific_heat": 1210.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.7,
+                    "visible_absorptance": 0.7
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic Wall Air Gap",
+                    "roughness": "Smooth",
+                    "thickness": 0.1,
+                    "conductivity": 0.667,
+                    "density": 1.28,
+                    "specific_heat": 1000.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.7,
+                    "visible_absorptance": 0.7
                 },
                 {
                     "type": "EnergyMaterial",
@@ -228,12 +207,6 @@
         "exterior_construction": {
             "type": "OpaqueConstruction",
             "identifier": "Generic Exposed Floor",
-            "layers": [
-                "Generic Painted Metal",
-                "Generic Ceiling Air Gap",
-                "Generic 50mm Insulation",
-                "Generic LW Concrete"
-            ],
             "materials": [
                 {
                     "type": "EnergyMaterial",
@@ -261,18 +234,6 @@
                 },
                 {
                     "type": "EnergyMaterial",
-                    "identifier": "Generic LW Concrete",
-                    "roughness": "MediumRough",
-                    "thickness": 0.1,
-                    "conductivity": 0.53,
-                    "density": 1280.0,
-                    "specific_heat": 840.0,
-                    "thermal_absorptance": 0.9,
-                    "solar_absorptance": 0.8,
-                    "visible_absorptance": 0.8
-                },
-                {
-                    "type": "EnergyMaterial",
                     "identifier": "Generic 50mm Insulation",
                     "roughness": "MediumRough",
                     "thickness": 0.05,
@@ -282,18 +243,24 @@
                     "thermal_absorptance": 0.9,
                     "solar_absorptance": 0.7,
                     "visible_absorptance": 0.7
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic LW Concrete",
+                    "roughness": "MediumRough",
+                    "thickness": 0.1,
+                    "conductivity": 0.53,
+                    "density": 1280.0,
+                    "specific_heat": 840.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.8,
+                    "visible_absorptance": 0.8
                 }
             ]
         },
         "interior_construction": {
             "type": "OpaqueConstruction",
             "identifier": "Generic Exposed Floor",
-            "layers": [
-                "Generic Painted Metal",
-                "Generic Ceiling Air Gap",
-                "Generic 50mm Insulation",
-                "Generic LW Concrete"
-            ],
             "materials": [
                 {
                     "type": "EnergyMaterial",
@@ -321,18 +288,6 @@
                 },
                 {
                     "type": "EnergyMaterial",
-                    "identifier": "Generic LW Concrete",
-                    "roughness": "MediumRough",
-                    "thickness": 0.1,
-                    "conductivity": 0.53,
-                    "density": 1280.0,
-                    "specific_heat": 840.0,
-                    "thermal_absorptance": 0.9,
-                    "solar_absorptance": 0.8,
-                    "visible_absorptance": 0.8
-                },
-                {
-                    "type": "EnergyMaterial",
                     "identifier": "Generic 50mm Insulation",
                     "roughness": "MediumRough",
                     "thickness": 0.05,
@@ -342,18 +297,24 @@
                     "thermal_absorptance": 0.9,
                     "solar_absorptance": 0.7,
                     "visible_absorptance": 0.7
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic LW Concrete",
+                    "roughness": "MediumRough",
+                    "thickness": 0.1,
+                    "conductivity": 0.53,
+                    "density": 1280.0,
+                    "specific_heat": 840.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.8,
+                    "visible_absorptance": 0.8
                 }
             ]
         },
         "ground_construction": {
             "type": "OpaqueConstruction",
             "identifier": "Generic Exposed Floor",
-            "layers": [
-                "Generic Painted Metal",
-                "Generic Ceiling Air Gap",
-                "Generic 50mm Insulation",
-                "Generic LW Concrete"
-            ],
             "materials": [
                 {
                     "type": "EnergyMaterial",
@@ -381,18 +342,6 @@
                 },
                 {
                     "type": "EnergyMaterial",
-                    "identifier": "Generic LW Concrete",
-                    "roughness": "MediumRough",
-                    "thickness": 0.1,
-                    "conductivity": 0.53,
-                    "density": 1280.0,
-                    "specific_heat": 840.0,
-                    "thermal_absorptance": 0.9,
-                    "solar_absorptance": 0.8,
-                    "visible_absorptance": 0.8
-                },
-                {
-                    "type": "EnergyMaterial",
                     "identifier": "Generic 50mm Insulation",
                     "roughness": "MediumRough",
                     "thickness": 0.05,
@@ -402,6 +351,18 @@
                     "thermal_absorptance": 0.9,
                     "solar_absorptance": 0.7,
                     "visible_absorptance": 0.7
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic LW Concrete",
+                    "roughness": "MediumRough",
+                    "thickness": 0.1,
+                    "conductivity": 0.53,
+                    "density": 1280.0,
+                    "specific_heat": 840.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.8,
+                    "visible_absorptance": 0.8
                 }
             ]
         }
@@ -411,13 +372,6 @@
         "exterior_construction": {
             "type": "OpaqueConstruction",
             "identifier": "Generic Roof",
-            "layers": [
-                "Generic Roof Membrane",
-                "Generic 50mm Insulation",
-                "Generic LW Concrete",
-                "Generic Ceiling Air Gap",
-                "Generic Acoustic Tile"
-            ],
             "materials": [
                 {
                     "type": "EnergyMaterial",
@@ -430,18 +384,6 @@
                     "thermal_absorptance": 0.9,
                     "solar_absorptance": 0.65,
                     "visible_absorptance": 0.65
-                },
-                {
-                    "type": "EnergyMaterial",
-                    "identifier": "Generic Ceiling Air Gap",
-                    "roughness": "Smooth",
-                    "thickness": 0.1,
-                    "conductivity": 0.556,
-                    "density": 1.28,
-                    "specific_heat": 1000.0,
-                    "thermal_absorptance": 0.9,
-                    "solar_absorptance": 0.7,
-                    "visible_absorptance": 0.7
                 },
                 {
                     "type": "EnergyMaterial",
@@ -466,6 +408,18 @@
                     "thermal_absorptance": 0.9,
                     "solar_absorptance": 0.8,
                     "visible_absorptance": 0.8
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic Ceiling Air Gap",
+                    "roughness": "Smooth",
+                    "thickness": 0.1,
+                    "conductivity": 0.556,
+                    "density": 1.28,
+                    "specific_heat": 1000.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.7,
+                    "visible_absorptance": 0.7
                 },
                 {
                     "type": "EnergyMaterial",
@@ -484,13 +438,6 @@
         "interior_construction": {
             "type": "OpaqueConstruction",
             "identifier": "Generic Roof",
-            "layers": [
-                "Generic Roof Membrane",
-                "Generic 50mm Insulation",
-                "Generic LW Concrete",
-                "Generic Ceiling Air Gap",
-                "Generic Acoustic Tile"
-            ],
             "materials": [
                 {
                     "type": "EnergyMaterial",
@@ -503,18 +450,6 @@
                     "thermal_absorptance": 0.9,
                     "solar_absorptance": 0.65,
                     "visible_absorptance": 0.65
-                },
-                {
-                    "type": "EnergyMaterial",
-                    "identifier": "Generic Ceiling Air Gap",
-                    "roughness": "Smooth",
-                    "thickness": 0.1,
-                    "conductivity": 0.556,
-                    "density": 1.28,
-                    "specific_heat": 1000.0,
-                    "thermal_absorptance": 0.9,
-                    "solar_absorptance": 0.7,
-                    "visible_absorptance": 0.7
                 },
                 {
                     "type": "EnergyMaterial",
@@ -539,6 +474,18 @@
                     "thermal_absorptance": 0.9,
                     "solar_absorptance": 0.8,
                     "visible_absorptance": 0.8
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic Ceiling Air Gap",
+                    "roughness": "Smooth",
+                    "thickness": 0.1,
+                    "conductivity": 0.556,
+                    "density": 1.28,
+                    "specific_heat": 1000.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.7,
+                    "visible_absorptance": 0.7
                 },
                 {
                     "type": "EnergyMaterial",
@@ -557,13 +504,6 @@
         "ground_construction": {
             "type": "OpaqueConstruction",
             "identifier": "Generic Roof",
-            "layers": [
-                "Generic Roof Membrane",
-                "Generic 50mm Insulation",
-                "Generic LW Concrete",
-                "Generic Ceiling Air Gap",
-                "Generic Acoustic Tile"
-            ],
             "materials": [
                 {
                     "type": "EnergyMaterial",
@@ -576,18 +516,6 @@
                     "thermal_absorptance": 0.9,
                     "solar_absorptance": 0.65,
                     "visible_absorptance": 0.65
-                },
-                {
-                    "type": "EnergyMaterial",
-                    "identifier": "Generic Ceiling Air Gap",
-                    "roughness": "Smooth",
-                    "thickness": 0.1,
-                    "conductivity": 0.556,
-                    "density": 1.28,
-                    "specific_heat": 1000.0,
-                    "thermal_absorptance": 0.9,
-                    "solar_absorptance": 0.7,
-                    "visible_absorptance": 0.7
                 },
                 {
                     "type": "EnergyMaterial",
@@ -612,6 +540,18 @@
                     "thermal_absorptance": 0.9,
                     "solar_absorptance": 0.8,
                     "visible_absorptance": 0.8
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic Ceiling Air Gap",
+                    "roughness": "Smooth",
+                    "thickness": 0.1,
+                    "conductivity": 0.556,
+                    "density": 1.28,
+                    "specific_heat": 1000.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.7,
+                    "visible_absorptance": 0.7
                 },
                 {
                     "type": "EnergyMaterial",
@@ -633,11 +573,6 @@
         "window_construction": {
             "type": "WindowConstruction",
             "identifier": "Generic Double Pane",
-            "layers": [
-                "Generic Low-e Glass",
-                "Generic Window Air Gap",
-                "Generic Clear Glass"
-            ],
             "materials": [
                 {
                     "type": "EnergyWindowMaterialGlazing",
@@ -684,9 +619,6 @@
         "interior_construction": {
             "type": "WindowConstruction",
             "identifier": "Generic Single Pane",
-            "layers": [
-                "Generic Clear Glass"
-            ],
             "materials": [
                 {
                     "type": "EnergyWindowMaterialGlazing",
@@ -710,11 +642,6 @@
         "skylight_construction": {
             "type": "WindowConstruction",
             "identifier": "Generic Double Pane",
-            "layers": [
-                "Generic Low-e Glass",
-                "Generic Window Air Gap",
-                "Generic Clear Glass"
-            ],
             "materials": [
                 {
                     "type": "EnergyWindowMaterialGlazing",
@@ -761,11 +688,6 @@
         "operable_construction": {
             "type": "WindowConstruction",
             "identifier": "Generic Double Pane",
-            "layers": [
-                "Generic Low-e Glass",
-                "Generic Window Air Gap",
-                "Generic Clear Glass"
-            ],
             "materials": [
                 {
                     "type": "EnergyWindowMaterialGlazing",
@@ -815,11 +737,6 @@
         "exterior_construction": {
             "type": "OpaqueConstruction",
             "identifier": "Generic Exterior Door",
-            "layers": [
-                "Generic Painted Metal",
-                "Generic 25mm Insulation",
-                "Generic Painted Metal"
-            ],
             "materials": [
                 {
                     "type": "EnergyMaterial",
@@ -844,15 +761,24 @@
                     "thermal_absorptance": 0.9,
                     "solar_absorptance": 0.7,
                     "visible_absorptance": 0.7
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic Painted Metal",
+                    "roughness": "Smooth",
+                    "thickness": 0.0015,
+                    "conductivity": 45.0,
+                    "density": 7690.0,
+                    "specific_heat": 410.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.5,
+                    "visible_absorptance": 0.5
                 }
             ]
         },
         "interior_construction": {
             "type": "OpaqueConstruction",
             "identifier": "Generic Interior Door",
-            "layers": [
-                "Generic 25mm Wood"
-            ],
             "materials": [
                 {
                     "type": "EnergyMaterial",
@@ -871,11 +797,6 @@
         "exterior_glass_construction": {
             "type": "WindowConstruction",
             "identifier": "Generic Double Pane",
-            "layers": [
-                "Generic Low-e Glass",
-                "Generic Window Air Gap",
-                "Generic Clear Glass"
-            ],
             "materials": [
                 {
                     "type": "EnergyWindowMaterialGlazing",
@@ -922,9 +843,6 @@
         "interior_glass_construction": {
             "type": "WindowConstruction",
             "identifier": "Generic Single Pane",
-            "layers": [
-                "Generic Clear Glass"
-            ],
             "materials": [
                 {
                     "type": "EnergyWindowMaterialGlazing",
@@ -948,11 +866,6 @@
         "overhead_construction": {
             "type": "OpaqueConstruction",
             "identifier": "Generic Exterior Door",
-            "layers": [
-                "Generic Painted Metal",
-                "Generic 25mm Insulation",
-                "Generic Painted Metal"
-            ],
             "materials": [
                 {
                     "type": "EnergyMaterial",
@@ -977,6 +890,18 @@
                     "thermal_absorptance": 0.9,
                     "solar_absorptance": 0.7,
                     "visible_absorptance": 0.7
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic Painted Metal",
+                    "roughness": "Smooth",
+                    "thickness": 0.0015,
+                    "conductivity": 45.0,
+                    "density": 7690.0,
+                    "specific_heat": 410.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.5,
+                    "visible_absorptance": 0.5
                 }
             ]
         }

--- a/spec/samples/construction_set/constructionset_partial_exterior.json
+++ b/spec/samples/construction_set/constructionset_partial_exterior.json
@@ -6,25 +6,7 @@
         "exterior_construction": {
             "type": "OpaqueConstruction",
             "identifier": "Typical Insulated Steel Framed Exterior Wall-R19",
-            "layers": [
-                "25mm Stucco",
-                "5/8 in. Gypsum Board",
-                "Typical Insulation-R17",
-                "5/8 in. Gypsum Board"
-            ],
             "materials": [
-                {
-                    "type": "EnergyMaterial",
-                    "identifier": "5/8 in. Gypsum Board",
-                    "roughness": "MediumSmooth",
-                    "thickness": 0.0159,
-                    "conductivity": 0.15989299909405463,
-                    "density": 800.0018291911765,
-                    "specific_heat": 1089.2971854559414,
-                    "thermal_absorptance": 0.9,
-                    "solar_absorptance": 0.7,
-                    "visible_absorptance": 0.7
-                },
                 {
                     "type": "EnergyMaterial",
                     "identifier": "25mm Stucco",
@@ -38,10 +20,34 @@
                     "visible_absorptance": 0.7
                 },
                 {
+                    "type": "EnergyMaterial",
+                    "identifier": "5/8 in. Gypsum Board",
+                    "roughness": "MediumSmooth",
+                    "thickness": 0.0159,
+                    "conductivity": 0.15989299909405463,
+                    "density": 800.0018291911765,
+                    "specific_heat": 1089.2971854559414,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.7,
+                    "visible_absorptance": 0.7
+                },
+                {
                     "type": "EnergyMaterialNoMass",
                     "identifier": "Typical Insulation-R17",
                     "r_value": 2.9938731247680423,
                     "roughness": "MediumSmooth",
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.7,
+                    "visible_absorptance": 0.7
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "5/8 in. Gypsum Board",
+                    "roughness": "MediumSmooth",
+                    "thickness": 0.0159,
+                    "conductivity": 0.15989299909405463,
+                    "density": 800.0018291911765,
+                    "specific_heat": 1089.2971854559414,
                     "thermal_absorptance": 0.9,
                     "solar_absorptance": 0.7,
                     "visible_absorptance": 0.7
@@ -52,10 +58,6 @@
         "ground_construction": {
             "type": "OpaqueConstruction",
             "identifier": "Typical Insulated Basement Mass Wall-R8",
-            "layers": [
-                "Typical Insulation-R7",
-                "8 in. Concrete Block Basement Wall"
-            ],
             "materials": [
                 {
                     "type": "EnergyMaterialNoMass",
@@ -86,14 +88,40 @@
         "exterior_construction": {
             "type": "OpaqueConstruction",
             "identifier": "Typical Insulated Steel Framed Exterior Floor-R27",
-            "layers": [
-                "25mm Stucco",
-                "5/8 in. Gypsum Board",
-                "Typical Insulation-R24",
-                "5/8 in. Gypsum Board",
-                "Typical Carpet Pad"
-            ],
             "materials": [
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "25mm Stucco",
+                    "roughness": "Smooth",
+                    "thickness": 0.0254,
+                    "conductivity": 0.7195184959232496,
+                    "density": 1856.0042437235265,
+                    "specific_heat": 839.4583814522845,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.7,
+                    "visible_absorptance": 0.7
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "5/8 in. Gypsum Board",
+                    "roughness": "MediumSmooth",
+                    "thickness": 0.0159,
+                    "conductivity": 0.15989299909405463,
+                    "density": 800.0018291911765,
+                    "specific_heat": 1089.2971854559414,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.7,
+                    "visible_absorptance": 0.7
+                },
+                {
+                    "type": "EnergyMaterialNoMass",
+                    "identifier": "Typical Insulation-R24",
+                    "r_value": 4.226644411437236,
+                    "roughness": "MediumSmooth",
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.7,
+                    "visible_absorptance": 0.7
+                },
                 {
                     "type": "EnergyMaterial",
                     "identifier": "5/8 in. Gypsum Board",
@@ -114,27 +142,6 @@
                     "thermal_absorptance": 0.9,
                     "solar_absorptance": 0.7,
                     "visible_absorptance": 0.8
-                },
-                {
-                    "type": "EnergyMaterial",
-                    "identifier": "25mm Stucco",
-                    "roughness": "Smooth",
-                    "thickness": 0.0254,
-                    "conductivity": 0.7195184959232496,
-                    "density": 1856.0042437235265,
-                    "specific_heat": 839.4583814522845,
-                    "thermal_absorptance": 0.9,
-                    "solar_absorptance": 0.7,
-                    "visible_absorptance": 0.7
-                },
-                {
-                    "type": "EnergyMaterialNoMass",
-                    "identifier": "Typical Insulation-R24",
-                    "r_value": 4.226644411437236,
-                    "roughness": "MediumSmooth",
-                    "thermal_absorptance": 0.9,
-                    "solar_absorptance": 0.7,
-                    "visible_absorptance": 0.7
                 }
             ]
         },
@@ -142,20 +149,15 @@
         "ground_construction": {
             "type": "OpaqueConstruction",
             "identifier": "Typical Insulated Carpeted 8in Slab Floor-R5",
-            "layers": [
-                "Typical Insulation-R4",
-                "8 in. Normalweight Concrete Floor",
-                "Typical Carpet Pad"
-            ],
             "materials": [
                 {
                     "type": "EnergyMaterialNoMass",
-                    "identifier": "Typical Carpet Pad",
-                    "r_value": 0.2164799871520999,
-                    "roughness": "VeryRough",
+                    "identifier": "Typical Insulation-R4",
+                    "r_value": 0.7044407352395393,
+                    "roughness": "MediumSmooth",
                     "thermal_absorptance": 0.9,
                     "solar_absorptance": 0.7,
-                    "visible_absorptance": 0.8
+                    "visible_absorptance": 0.7
                 },
                 {
                     "type": "EnergyMaterial",
@@ -171,12 +173,12 @@
                 },
                 {
                     "type": "EnergyMaterialNoMass",
-                    "identifier": "Typical Insulation-R4",
-                    "r_value": 0.7044407352395393,
-                    "roughness": "MediumSmooth",
+                    "identifier": "Typical Carpet Pad",
+                    "r_value": 0.2164799871520999,
+                    "roughness": "VeryRough",
                     "thermal_absorptance": 0.9,
                     "solar_absorptance": 0.7,
-                    "visible_absorptance": 0.7
+                    "visible_absorptance": 0.8
                 }
             ]
         }
@@ -186,24 +188,7 @@
         "exterior_construction": {
             "type": "OpaqueConstruction",
             "identifier": "Typical IEAD Roof-R32",
-            "layers": [
-                "Roof Membrane",
-                "Typical Insulation-R31",
-                "Metal Roof Surface"
-            ],
             "materials": [
-                {
-                    "type": "EnergyMaterial",
-                    "identifier": "Metal Roof Surface",
-                    "roughness": "Smooth",
-                    "thickness": 0.0007999999999999979,
-                    "conductivity": 45.24971874361766,
-                    "density": 7824.017889489713,
-                    "specific_heat": 499.67760800730963,
-                    "thermal_absorptance": 0.9,
-                    "solar_absorptance": 0.7,
-                    "visible_absorptance": 0.7
-                },
                 {
                     "type": "EnergyMaterial",
                     "identifier": "Roof Membrane",
@@ -224,6 +209,18 @@
                     "thermal_absorptance": 0.9,
                     "solar_absorptance": 0.7,
                     "visible_absorptance": 0.7
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Metal Roof Surface",
+                    "roughness": "Smooth",
+                    "thickness": 0.0007999999999999979,
+                    "conductivity": 45.24971874361766,
+                    "density": 7824.017889489713,
+                    "specific_heat": 499.67760800730963,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.7,
+                    "visible_absorptance": 0.7
                 }
             ]
         },
@@ -235,18 +232,7 @@
         "window_construction": {
             "type": "WindowConstruction",
             "identifier": "U 0.48 SHGC 0.40 Dbl Ref-D Clr 6mm/13mm",
-            "layers": [
-                "REF D CLEAR 6MM",
-                "AIR 13MM",
-                "CLEAR 6MM"
-            ],
             "materials": [
-                {
-                    "type": "EnergyWindowMaterialGas",
-                    "identifier": "AIR 13MM",
-                    "thickness": 0.0127,
-                    "gas_type": "Air"
-                },
                 {
                     "type": "EnergyWindowMaterialGlazing",
                     "identifier": "REF D CLEAR 6MM",
@@ -263,6 +249,12 @@
                     "conductivity": 0.8993981199040626,
                     "dirt_correction": 1.0,
                     "solar_diffusing": false
+                },
+                {
+                    "type": "EnergyWindowMaterialGas",
+                    "identifier": "AIR 13MM",
+                    "thickness": 0.0127,
+                    "gas_type": "Air"
                 },
                 {
                     "type": "EnergyWindowMaterialGlazing",
@@ -287,29 +279,7 @@
         "skylight_construction": {
             "type": "WindowConstruction",
             "identifier": "Window_U_0.50_SHGC_0.40_Skylight_Frame_Width_0.430_in",
-            "layers": [
-                "Glass_2052_LayerAvg",
-                "Gap_1_W_0_0038",
-                "Glass_2027F_LayerAvg"
-            ],
             "materials": [
-                {
-                    "type": "EnergyWindowMaterialGlazing",
-                    "identifier": "Glass_2027F_LayerAvg",
-                    "thickness": 0.003999999999999977,
-                    "solar_transmittance": 0.369744,
-                    "solar_reflectance": 0.4700695,
-                    "solar_reflectance_back": 0.340935,
-                    "visible_transmittance": 0.765222,
-                    "visible_reflectance": 0.0546,
-                    "visible_reflectance_back": 0.073741,
-                    "infrared_transmittance": 0.0,
-                    "emissivity": 0.03675,
-                    "emissivity_back": 0.84,
-                    "conductivity": 0.9993312443378461,
-                    "dirt_correction": 1.0,
-                    "solar_diffusing": false
-                },
                 {
                     "type": "EnergyWindowMaterialGlazing",
                     "identifier": "Glass_2052_LayerAvg",
@@ -332,24 +302,30 @@
                     "identifier": "Gap_1_W_0_0038",
                     "thickness": 0.0037999999999999887,
                     "gas_type": "Air"
+                },
+                {
+                    "type": "EnergyWindowMaterialGlazing",
+                    "identifier": "Glass_2027F_LayerAvg",
+                    "thickness": 0.003999999999999977,
+                    "solar_transmittance": 0.369744,
+                    "solar_reflectance": 0.4700695,
+                    "solar_reflectance_back": 0.340935,
+                    "visible_transmittance": 0.765222,
+                    "visible_reflectance": 0.0546,
+                    "visible_reflectance_back": 0.073741,
+                    "infrared_transmittance": 0.0,
+                    "emissivity": 0.03675,
+                    "emissivity_back": 0.84,
+                    "conductivity": 0.9993312443378461,
+                    "dirt_correction": 1.0,
+                    "solar_diffusing": false
                 }
             ]
         },
         "operable_construction": {
             "type": "WindowConstruction",
             "identifier": "U 0.48 SHGC 0.40 Dbl Ref-D Clr 6mm/13mm",
-            "layers": [
-                "REF D CLEAR 6MM",
-                "AIR 13MM",
-                "CLEAR 6MM"
-            ],
             "materials": [
-                {
-                    "type": "EnergyWindowMaterialGas",
-                    "identifier": "AIR 13MM",
-                    "thickness": 0.0127,
-                    "gas_type": "Air"
-                },
                 {
                     "type": "EnergyWindowMaterialGlazing",
                     "identifier": "REF D CLEAR 6MM",
@@ -366,6 +342,12 @@
                     "conductivity": 0.8993981199040626,
                     "dirt_correction": 1.0,
                     "solar_diffusing": false
+                },
+                {
+                    "type": "EnergyWindowMaterialGas",
+                    "identifier": "AIR 13MM",
+                    "thickness": 0.0127,
+                    "gas_type": "Air"
                 },
                 {
                     "type": "EnergyWindowMaterialGlazing",
@@ -392,10 +374,6 @@
         "exterior_construction": {
             "type": "OpaqueConstruction",
             "identifier": "Typical Insulated Metal Door-R2",
-            "layers": [
-                "F08 Metal surface",
-                "Typical Insulation-R2"
-            ],
             "materials": [
                 {
                     "type": "EnergyMaterial",
@@ -424,18 +402,7 @@
         "exterior_glass_construction": {
             "type": "WindowConstruction",
             "identifier": "U 0.44 SHGC 0.26 Dbl Ref-B-H Clr 6mm/13mm Air",
-            "layers": [
-                "REF B CLEAR HI 6MM",
-                "AIR 13MM",
-                "CLEAR 6MM"
-            ],
             "materials": [
-                {
-                    "type": "EnergyWindowMaterialGas",
-                    "identifier": "AIR 13MM",
-                    "thickness": 0.0127,
-                    "gas_type": "Air"
-                },
                 {
                     "type": "EnergyWindowMaterialGlazing",
                     "identifier": "REF B CLEAR HI 6MM",
@@ -452,6 +419,12 @@
                     "conductivity": 0.8993981199040626,
                     "dirt_correction": 1.0,
                     "solar_diffusing": false
+                },
+                {
+                    "type": "EnergyWindowMaterialGas",
+                    "identifier": "AIR 13MM",
+                    "thickness": 0.0127,
+                    "gas_type": "Air"
                 },
                 {
                     "type": "EnergyWindowMaterialGlazing",
@@ -476,9 +449,6 @@
         "overhead_construction": {
             "type": "OpaqueConstruction",
             "identifier": "Typical Overhead Door-R2",
-            "layers": [
-                "Typical Insulation-R2"
-            ],
             "materials": [
                 {
                     "type": "EnergyMaterialNoMass",

--- a/spec/samples/model/model_complete_multi_zone_office.hbjson
+++ b/spec/samples/model/model_complete_multi_zone_office.hbjson
@@ -52,7 +52,7 @@
                 {
                     "type": "OpaqueConstructionAbridged",
                     "identifier": "Attic Floor Construction",
-                    "layers": [
+                    "materials": [
                         "Generic 25mm Wood",
                         "Generic 50mm Insulation",
                         "Generic 25mm Wood"
@@ -61,7 +61,7 @@
                 {
                     "type": "OpaqueConstructionAbridged",
                     "identifier": "Attic Roof Construction",
-                    "layers": [
+                    "materials": [
                         "Generic Roof Membrane",
                         "PolyIso",
                         "Generic 25mm Wood"

--- a/spec/samples/model/model_complete_single_zone_office.hbjson
+++ b/spec/samples/model/model_complete_single_zone_office.hbjson
@@ -19,7 +19,7 @@
                 {
                     "type": "OpaqueConstructionAbridged",
                     "identifier": "Thermal Mass Floor",
-                    "layers": [
+                    "materials": [
                         "Thick Stone"
                     ]
                 },
@@ -33,7 +33,7 @@
                 {
                     "type": "WindowConstructionAbridged",
                     "identifier": "Triple Pane Window",
-                    "layers": [
+                    "materials": [
                         "Generic Clear Glass",
                         "Generic Window Air Gap",
                         "Generic Clear Glass",

--- a/spec/samples/model/model_energy_no_program.hbjson
+++ b/spec/samples/model/model_energy_no_program.hbjson
@@ -19,7 +19,7 @@
                 {
                     "type": "OpaqueConstructionAbridged",
                     "identifier": "Thermal Mass Floor",
-                    "layers": [
+                    "materials": [
                         "Thick Stone"
                     ]
                 },
@@ -33,7 +33,7 @@
                 {
                     "type": "WindowConstructionAbridged",
                     "identifier": "Triple Pane Window",
-                    "layers": [
+                    "materials": [
                         "Generic Clear Glass",
                         "Generic Window Air Gap",
                         "Generic Clear Glass",

--- a/spec/samples/model/model_energy_shoe_box.hbjson
+++ b/spec/samples/model/model_energy_shoe_box.hbjson
@@ -52,7 +52,7 @@
                 {
                     "type": "OpaqueConstructionAbridged",
                     "identifier": "Generic Interior Floor",
-                    "layers": [
+                    "materials": [
                         "Generic Acoustic Tile",
                         "Generic Ceiling Air Gap",
                         "Generic LW Concrete"
@@ -61,7 +61,7 @@
                 {
                     "type": "OpaqueConstructionAbridged",
                     "identifier": "Generic Interior Wall",
-                    "layers": [
+                    "materials": [
                         "Generic Gypsum Board",
                         "Generic Wall Air Gap",
                         "Generic Gypsum Board"
@@ -70,7 +70,7 @@
                 {
                     "type": "WindowConstructionAbridged",
                     "identifier": "Generic Double Pane",
-                    "layers": [
+                    "materials": [
                         "Generic Low-e Glass",
                         "Generic Window Air Gap",
                         "Generic Clear Glass"
@@ -79,7 +79,7 @@
                 {
                     "type": "OpaqueConstructionAbridged",
                     "identifier": "Generic Interior Ceiling",
-                    "layers": [
+                    "materials": [
                         "Generic LW Concrete",
                         "Generic Ceiling Air Gap",
                         "Generic Acoustic Tile"
@@ -88,7 +88,7 @@
                 {
                     "type": "OpaqueConstructionAbridged",
                     "identifier": "Generic Exterior Wall",
-                    "layers": [
+                    "materials": [
                         "Generic Brick",
                         "Generic LW Concrete",
                         "Generic 50mm Insulation",

--- a/spec/samples/model_large/lab_building.hbjson
+++ b/spec/samples/model_large/lab_building.hbjson
@@ -52,14 +52,14 @@
                 {
                     "type": "OpaqueConstructionAbridged",
                     "identifier": "Typical Overhead Door-R2",
-                    "layers": [
+                    "materials": [
                         "Typical Insulation-R2"
                     ]
                 },
                 {
                     "type": "WindowConstructionAbridged",
                     "identifier": "U 0.44 SHGC 0.26 Dbl Ref-B-H Clr 6mm/13mm Air",
-                    "layers": [
+                    "materials": [
                         "REF B CLEAR HI 6MM",
                         "AIR 13MM",
                         "CLEAR 6MM"
@@ -68,7 +68,7 @@
                 {
                     "type": "WindowConstructionAbridged",
                     "identifier": "U 0.48 SHGC 0.40 Dbl Ref-D Clr 6mm/13mm",
-                    "layers": [
+                    "materials": [
                         "REF D CLEAR 6MM",
                         "AIR 13MM",
                         "CLEAR 6MM"
@@ -77,7 +77,7 @@
                 {
                     "type": "OpaqueConstructionAbridged",
                     "identifier": "Typical Insulated Metal Door-R2",
-                    "layers": [
+                    "materials": [
                         "F08 Metal surface",
                         "Typical Insulation-R2"
                     ]
@@ -85,7 +85,7 @@
                 {
                     "type": "OpaqueConstructionAbridged",
                     "identifier": "Typical Insulated Basement Mass Wall-R8",
-                    "layers": [
+                    "materials": [
                         "Typical Insulation-R7",
                         "8 in. Concrete Block Basement Wall"
                     ]
@@ -93,7 +93,7 @@
                 {
                     "type": "OpaqueConstructionAbridged",
                     "identifier": "Typical IEAD Roof-R32",
-                    "layers": [
+                    "materials": [
                         "Roof Membrane",
                         "Typical Insulation-R31",
                         "Metal Roof Surface"
@@ -102,7 +102,7 @@
                 {
                     "type": "WindowConstructionAbridged",
                     "identifier": "Window_U_0.50_SHGC_0.40_Skylight_Frame_Width_0.430_in",
-                    "layers": [
+                    "materials": [
                         "Glass_2052_LayerAvg",
                         "Gap_1_W_0_0038",
                         "Glass_2027F_LayerAvg"
@@ -111,7 +111,7 @@
                 {
                     "type": "OpaqueConstructionAbridged",
                     "identifier": "Typical Insulated Steel Framed Exterior Wall-R19",
-                    "layers": [
+                    "materials": [
                         "25mm Stucco",
                         "5/8 in. Gypsum Board",
                         "Typical Insulation-R17",
@@ -121,7 +121,7 @@
                 {
                     "type": "OpaqueConstructionAbridged",
                     "identifier": "Typical Insulated Carpeted 8in Slab Floor-R5",
-                    "layers": [
+                    "materials": [
                         "Typical Insulation-R4",
                         "8 in. Normalweight Concrete Floor",
                         "Typical Carpet Pad"
@@ -130,7 +130,7 @@
                 {
                     "type": "OpaqueConstructionAbridged",
                     "identifier": "Typical Insulated Steel Framed Exterior Floor-R27",
-                    "layers": [
+                    "materials": [
                         "25mm Stucco",
                         "5/8 in. Gypsum Board",
                         "Typical Insulation-R24",

--- a/spec/samples/model_large/single_family_home.hbjson
+++ b/spec/samples/model_large/single_family_home.hbjson
@@ -52,14 +52,14 @@
                 {
                     "type": "OpaqueConstructionAbridged",
                     "identifier": "Typical Overhead Door-R2",
-                    "layers": [
+                    "materials": [
                         "Typical Insulation-R2"
                     ]
                 },
                 {
                     "type": "WindowConstructionAbridged",
                     "identifier": "U 0.44 SHGC 0.26 Dbl Ref-B-H Clr 6mm/13mm Air",
-                    "layers": [
+                    "materials": [
                         "REF B CLEAR HI 6MM",
                         "AIR 13MM",
                         "CLEAR 6MM"
@@ -68,7 +68,7 @@
                 {
                     "type": "WindowConstructionAbridged",
                     "identifier": "U 0.48 SHGC 0.40 Dbl Ref-D Clr 6mm/13mm",
-                    "layers": [
+                    "materials": [
                         "REF D CLEAR 6MM",
                         "AIR 13MM",
                         "CLEAR 6MM"
@@ -77,7 +77,7 @@
                 {
                     "type": "OpaqueConstructionAbridged",
                     "identifier": "Typical Insulated Metal Door-R2",
-                    "layers": [
+                    "materials": [
                         "F08 Metal surface",
                         "Typical Insulation-R2"
                     ]
@@ -85,7 +85,7 @@
                 {
                     "type": "OpaqueConstructionAbridged",
                     "identifier": "Typical Insulated Basement Mass Wall-R8",
-                    "layers": [
+                    "materials": [
                         "Typical Insulation-R7",
                         "8 in. Concrete Block Basement Wall"
                     ]
@@ -93,7 +93,7 @@
                 {
                     "type": "OpaqueConstructionAbridged",
                     "identifier": "Typical IEAD Roof-R32",
-                    "layers": [
+                    "materials": [
                         "Roof Membrane",
                         "Typical Insulation-R31",
                         "Metal Roof Surface"
@@ -102,7 +102,7 @@
                 {
                     "type": "WindowConstructionAbridged",
                     "identifier": "Window_U_0.50_SHGC_0.40_Skylight_Frame_Width_0.430_in",
-                    "layers": [
+                    "materials": [
                         "Glass_2052_LayerAvg",
                         "Gap_1_W_0_0038",
                         "Glass_2027F_LayerAvg"
@@ -111,7 +111,7 @@
                 {
                     "type": "OpaqueConstructionAbridged",
                     "identifier": "Typical Insulated Steel Framed Exterior Wall-R19",
-                    "layers": [
+                    "materials": [
                         "25mm Stucco",
                         "5/8 in. Gypsum Board",
                         "Typical Insulation-R17",
@@ -121,7 +121,7 @@
                 {
                     "type": "OpaqueConstructionAbridged",
                     "identifier": "Typical Insulated Carpeted 8in Slab Floor-R5",
-                    "layers": [
+                    "materials": [
                         "Typical Insulation-R4",
                         "8 in. Normalweight Concrete Floor",
                         "Typical Carpet Pad"
@@ -130,7 +130,7 @@
                 {
                     "type": "OpaqueConstructionAbridged",
                     "identifier": "Typical Insulated Steel Framed Exterior Floor-R27",
-                    "layers": [
+                    "materials": [
                         "25mm Stucco",
                         "5/8 in. Gypsum Board",
                         "Typical Insulation-R24",

--- a/spec/tests/honeybee_construction_spec.rb
+++ b/spec/tests/honeybee_construction_spec.rb
@@ -59,11 +59,6 @@ RSpec.describe Honeybee do
     construction1 = Honeybee::OpaqueConstructionAbridged.read_from_disk(file)
     object1 = construction1.to_openstudio(openstudio_model)
     expect(object1).not_to be nil
-
-    layers = construction1.layers
-    expect(layers).not_to be nil
-    expect(layers.size).to eq(5)
-
   end
 
   it 'can load construction opaque wall' do


### PR DESCRIPTION
I have come around to realizing that the OpaqueConstruction and WindowConstruction should use the key "materials" instead of "layers" in order to be consistent between abridged and non-abridged schemas.

I am changing the forward translator to accept both the old and new schema.

@tanushree , this will affect the reverse translator that you are currently working on since you should translate the constructions to the new schema (with the "materials" key instead of the "layers" key).