### PR TITLE
fix(gbxml): Add extra checks to comply with gbXML

### DIFF
--- a/lib/from_openstudio/model.rb
+++ b/lib/from_openstudio/model.rb
@@ -81,7 +81,15 @@ module Honeybee
       translator = OpenStudio::GbXML::GbXMLReverseTranslator.new
       openstudio_model = translator.loadModel(file)
       raise "Cannot load gbXML file at '#{}'" if openstudio_model.empty?
-      self.translate_from_openstudio(openstudio_model.get)
+      # remove any shade groups that were translated as spaces
+      os_model = openstudio_model.get
+      spaces = os_model.getSpaces()
+      spaces.each do |space|
+        if space.surfaces.length() == 0
+          space.remove()
+        end
+      end
+      self.translate_from_openstudio(os_model)
     end
 
     # Create Ladybug Energy Model JSON from IDF file

--- a/lib/measures/from_honeybee_model_to_gbxml/measure.rb
+++ b/lib/measures/from_honeybee_model_to_gbxml/measure.rb
@@ -90,6 +90,13 @@ class FromHoneybeeModelToGbxml < OpenStudio::Measure::ModelMeasure
     os_model = honeybee_model.to_openstudio_model(model)
     STDOUT.flush
 
+    # make sure the zone name is different from the space name to comply with gbXML
+    zones = os_model.getThermalZones()
+    zones.each do |zone|
+      zone_name = zone.name.to_s + '_Zone'
+      zone.setName(zone_name)
+    end
+
     # convert the OpenStudio model into a gbXML Model
     output_file_path = runner.getStringArgumentValue('output_file_path', user_arguments)
     if output_file_path && !output_file_path.empty?


### PR DESCRIPTION
This includes the removal of the "dummy space" on import that you need to put into gbXML in order to have context shade. It also includes making sure that the zone name is always different than the space name.