### PR TITLE
fix(construction): Ensure output is valid with missing constructions

### DIFF
--- a/lib/from_openstudio/geometry/aperture.rb
+++ b/lib/from_openstudio/geometry/aperture.rb
@@ -71,7 +71,10 @@ module Honeybee
 
       construction = sub_surface.construction
       if !construction.empty?
-        hash[:construction] = construction.get.nameString
+        constr_id = construction.get.nameString
+        unless $window_constructions[constr_id].nil?
+          hash[:construction] = constr_id
+        end
       end
 
       hash

--- a/lib/from_openstudio/geometry/door.rb
+++ b/lib/from_openstudio/geometry/door.rb
@@ -71,7 +71,12 @@ module Honeybee
 
       construction = sub_surface.construction
       if !construction.empty?
-        hash[:construction] = construction.get.nameString
+        constr_id = construction.get.nameString
+        if hash[:is_glass] && !$window_constructions[constr_id].nil?
+          hash[:construction] = constr_id
+        elsif !hash[:is_glass] && !$opaque_constructions[constr_id].nil?
+          hash[:construction] = constr_id
+        end
       end
 
       hash

--- a/lib/from_openstudio/geometry/face.rb
+++ b/lib/from_openstudio/geometry/face.rb
@@ -73,7 +73,10 @@ module Honeybee
 
       construction = surface.construction
       if !construction.empty?
-        hash[:construction] = construction.get.nameString
+        constr_id = construction.get.nameString
+        unless $opaque_constructions[constr_id].nil?
+          hash[:construction] = constr_id
+        end
       end
 
       hash

--- a/lib/from_openstudio/geometry/shade.rb
+++ b/lib/from_openstudio/geometry/shade.rb
@@ -63,10 +63,10 @@ module Honeybee
       if !construction.empty?
         const_name = construction.get.nameString
         hash[:construction] = const_name
-        unless $shade_construction.has_key?(const_name)
+        unless $shade_constructions.has_key?(const_name)
           const_obj = construction.get
           const = const_obj.to_LayeredConstruction.get
-          $shade_construction[const_name] = const
+          $shade_constructions[const_name] = const
         end
       end
 


### PR DESCRIPTION
I realized that the format of window constructions within gbXML doesn't support material layers and so the current setup of the gem meant that almost no gbXMLs were importable back to honeybee. I added in some checks to ensure that, if a construction is not found, we don't assign it to any faces. This keeps the output HBJSON valid and ensures that these objects with missing constructions just get the honeybee default.