### PR TITLE
fix(glazing): Ensure that the numerical value is obtained

### DIFF
--- a/lib/from_openstudio/material/window_glazing.rb
+++ b/lib/from_openstudio/material/window_glazing.rb
@@ -61,7 +61,7 @@ module Honeybee
         end
         # check if boost optional object is empty
         unless material.backSideVisibleReflectanceatNormalIncidence.empty?
-            hash[:visible_reflectance_back] = material.backSideVisibleReflectanceatNormalIncidence
+            hash[:visible_reflectance_back] = material.backSideVisibleReflectanceatNormalIncidence.get
         end
         hash[:infrared_transmittance] = material.infraredTransmittance
         hash[:emissivity] = material.frontSideInfraredHemisphericalEmissivity


### PR DESCRIPTION
It seems that, if we don't .get the value, it gets written into the JSON as a string.