### PR TITLE
fix(afn): Handle the case of horizontal Apertures

### DIFF
--- a/lib/to_openstudio/geometry/face.rb
+++ b/lib/to_openstudio/geometry/face.rb
@@ -77,7 +77,7 @@ module Honeybee
 
           # assign the flow exponent if it's specified
           if vent_crack[:flow_exponent]
-            os_crack.	setAirMassFlowExponent(vent_crack[:flow_exponent])
+            os_crack.setAirMassFlowExponent(vent_crack[:flow_exponent])
           end
 
           # if it's a Surface boundary condition ensure the neighbor is not written as a duplicate

--- a/lib/to_openstudio/geometry/room.rb
+++ b/lib/to_openstudio/geometry/room.rb
@@ -349,8 +349,10 @@ module Honeybee
             if sub_f.adjacentSubSurface.empty?  # not an interior window that's already in the AFN
               vent_open = VentilationOpening.new(opening)
               open_fac = vent_open.to_openstudio_afn(openstudio_model, sub_f)
-              operable_subfs << sub_f
-              opening_factors << open_fac
+              unless open_fac.nil?  # nil is used for horizontal exterior skylights
+                operable_subfs << sub_f
+                opening_factors << open_fac
+              end
             end
           end
         end


### PR DESCRIPTION
This commit ensures that horizontal apertures can be simulated with the AFN. There currently aren't any checks to ensure that horizontal exterior apertures are-inoperable but these are better addressed on the UI end.