### PR TITLE
fix(model): Ensure autocalculated properties make it to IDF and gbXML

### DIFF
--- a/lib/honeybee/_defaults/energy_default.json
+++ b/lib/honeybee/_defaults/energy_default.json
@@ -54,7 +54,10 @@
             "identifier": "Generic Single Pane",
             "materials": [
                 "Generic Clear Glass"
-            ]
+            ],
+            "u_factor": 5.731373,
+            "shgc": 0.824407,
+            "vt": 0.88
         },
         {
             "type": "ShadeConstruction",
@@ -170,7 +173,10 @@
                 "Generic Low-e Glass",
                 "Generic Window Air Gap",
                 "Generic Clear Glass"
-            ]
+            ],
+            "u_factor": 1.687787,
+            "shgc": 0.43651,
+            "vt": 0.635473
         },
         {
             "type": "OpaqueConstructionAbridged",

--- a/lib/honeybee/model.rb
+++ b/lib/honeybee/model.rb
@@ -51,6 +51,7 @@ module Honeybee
       @@extension ||= Extension.new
       @@schema ||= @@extension.schema
       @@standards ||= @@extension.standards
+      $simple_window_cons = false
 
       @hash = hash
       @type = @hash[:type]

--- a/lib/measures/from_honeybee_model_to_gbxml/measure.rb
+++ b/lib/measures/from_honeybee_model_to_gbxml/measure.rb
@@ -86,6 +86,7 @@ class FromHoneybeeModelToGbxml < OpenStudio::Measure::ModelMeasure
       return false
     end
     honeybee_model = Honeybee::Model.read_from_disk(model_json)
+    $simple_window_cons = true
     STDOUT.flush
     os_model = honeybee_model.to_openstudio_model(model)
     STDOUT.flush

--- a/lib/to_openstudio/construction/window.rb
+++ b/lib/to_openstudio/construction/window.rb
@@ -50,16 +50,25 @@ module Honeybee
       # create material vector
       os_materials = OpenStudio::Model::MaterialVector.new
       # loop through each layer and add to material vector
-      if @hash.key?(:layers)
-        mat_key = :layers
+      if $simple_window_cons && @hash[:u_factor]
+        os_simple_glazing = OpenStudio::Model::SimpleGlazing.new(openstudio_model)
+        os_simple_glazing.setName(@hash[:identifier] + '_SimpleGlazSys')
+        os_simple_glazing.setUFactor(@hash[:u_factor])
+        os_simple_glazing.setSolarHeatGainCoefficient(@hash[:shgc])
+        os_simple_glazing.setVisibleTransmittance(@hash[:vt])
+        os_materials << os_simple_glazing
       else
-        mat_key = :materials
-      end
-      @hash[mat_key].each do |material_identifier|
-        material = openstudio_model.getMaterialByName(material_identifier)
-        unless material.empty?
-          os_material = material.get
-          os_materials << os_material
+        if @hash.key?(:layers)
+          mat_key = :layers
+        else
+          mat_key = :materials
+        end
+        @hash[mat_key].each do |material_identifier|
+          material = openstudio_model.getMaterialByName(material_identifier)
+          unless material.empty?
+            os_material = material.get
+            os_materials << os_material
+          end
         end
       end
       os_construction.setLayers(os_materials)

--- a/lib/to_openstudio/geometry/room.rb
+++ b/lib/to_openstudio/geometry/room.rb
@@ -105,6 +105,14 @@ module Honeybee
         os_thermal_zone.setMultiplier(@hash[:multiplier])
       end
 
+      # assign the geometry properties if they exist
+      if @hash[:ceiling_height]
+        os_thermal_zone.setCeilingHeight(@hash[:ceiling_height])
+      end
+      if @hash[:volume]
+        os_thermal_zone.setVolume(@hash[:volume])
+      end
+
       # assign the story
       if @hash[:story]  # the users has specified the name of the story
         story = openstudio_model.getBuildingStoryByName(@hash[:story])


### PR DESCRIPTION
This commit ensures that properties like honeybee-calculated room volume make it into the IDF. It also ensures that properties like U-value and SHGC make it into the gbXML.