### PR TITLE
fix(style): Remove deprecated args and incorrect default

### DIFF
--- a/lib/from_openstudio/schedule/type_limit.rb
+++ b/lib/from_openstudio/schedule/type_limit.rb
@@ -65,6 +65,8 @@ module Honeybee
         unit_type = 'ConvectionCoefficient'
       elsif unit_type == 'Activitylevel'
         unit_type = 'ActivityLevel'
+      elsif unit_type == 'Controlmode'
+        unit_type = 'Control'
       end
       hash[:unit_type] = unit_type
 

--- a/lib/honeybee/model_object.rb
+++ b/lib/honeybee/model_object.rb
@@ -36,13 +36,6 @@ module Honeybee
 
     attr_reader :errors, :warnings
 
-    @@encoding_options = {
-      :invalid           => :replace,  # Replace invalid byte sequences
-      :undef             => :replace,  # Replace anything not defined in ASCII
-      :replace           => '',        # Use a blank for those replacements
-      :universal_newline => true       # Always break lines with \n
-    }
-
     def method_missing(sym, *args)
       name = sym.to_s
       aname = name.sub('=', '')
@@ -107,12 +100,12 @@ module Honeybee
 
     # remove illegal characters in identifier
     def self.clean_name(str)
-      ascii = str.encode(Encoding.find('ASCII'), @@encoding_options)
+      ascii = str.encode(Encoding.find('ASCII'))
     end
 
     # remove illegal characters in identifier
     def self.clean_identifier(str)
-      encode_str = str.encode(Encoding.find('ASCII'), @@encoding_options)
+      encode_str = str.encode(Encoding.find('ASCII'))
       encode_str.gsub(/[^.A-Za-z0-9_-]/, '_').gsub(' ', '_')
     end
 

--- a/spec/samples/idf/5ZoneAirCooled.idf
+++ b/spec/samples/idf/5ZoneAirCooled.idf
@@ -100,7 +100,7 @@
 ! Environmental Emissions:        None
 ! Utility Tariffs:                None
 
-  Version,9.4;
+  Version,9.5.0;
 
   Building,
     Building,                !- Name

--- a/spec/samples/osm_schedule/scheduleRuleset.osm
+++ b/spec/samples/osm_schedule/scheduleRuleset.osm
@@ -173,11 +173,11 @@ OS:ScheduleTypeLimits,
 
 OS:ScheduleTypeLimits,
   {128dfdb0-7db4-4449-af1e-67186955ce41}, !- Handle
-  ControlMode,                            !- Name
+  Control,                                !- Name
   0,                                      !- Lower Limit Value
   1,                                      !- Upper Limit Value
   Discrete,                               !- Numeric Type
-  ControlMode;                            !- Unit Type
+  Control;                                !- Unit Type
 
 OS:ScheduleTypeLimits,
   {1dcc991b-3a00-49ab-87ef-5ef55823c490}, !- Handle

--- a/spec/tests/idf_to_honeybee_spec.rb
+++ b/spec/tests/idf_to_honeybee_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Honeybee do
 
     honeybee.validation_errors.each {|error| puts error}
 
-    #expect(honeybee.valid?).to be true
+    expect(honeybee.valid?).to be true
     hash = honeybee.hash
     expect(hash[:type]).not_to be_nil
     expect(hash[:type]).to eq 'Model'

--- a/spec/tests/osm_schedules_spec.rb
+++ b/spec/tests/osm_schedules_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Honeybee do
     vt = OpenStudio::OSVersion::VersionTranslator.new
     openstudio_model = vt.loadModel(file)
 
-    # create HB JSON material from OS model
+    # create HBJSON hash from OS model
     honeybee = Honeybee::Model.schedtypelimits_from_model(openstudio_model.get)
 
     # check values
@@ -66,7 +66,7 @@ RSpec.describe Honeybee do
     vt = OpenStudio::OSVersion::VersionTranslator.new
     openstudio_model = vt.loadModel(file)
 
-    # create HB JSON material from OS model
+    # create HBJSON hash from OS model
     honeybee = Honeybee::Model.scheduleruleset_from_model(openstudio_model.get)
 
     # check values


### PR DESCRIPTION
It seems that one of the arguments I was using for encoding ASCII is deprecated. Also, it seems that there's an old default in the OpenStudio SDK in regard to the ControlMode unit type. This can catch and fix this case.