### PR TITLE
fix(ems): Ensure that correct EMS variables are always used

### DIFF
--- a/lib/to_openstudio/construction/dynamic.rb
+++ b/lib/to_openstudio/construction/dynamic.rb
@@ -88,7 +88,7 @@ module Honeybee
 
       # set up the EMS sensor for the schedule value
       state_sch = openstudio_model.getScheduleByName(@hash[:schedule])
-      @sch_sensor_name = replace_ems_special_characters(@hash[:identifier]) + '_Sensor' + @@sensor_count.to_s
+      @sch_sensor_name = replace_ems_special_characters(@hash[:identifier]) + 'Sensor' + @@sensor_count.to_s
       @@sensor_count = @@sensor_count + 1
       unless state_sch.empty?  # schedule not specified
         sch_var = OpenStudio::Model::OutputVariable.new('Schedule Value', openstudio_model)
@@ -107,18 +107,15 @@ module Honeybee
       @sub_faces.each do |dyn_window|
         window_act = OpenStudio::Model::EnergyManagementSystemActuator.new(
           dyn_window, 'Surface', 'Construction State')
-        dyn_window_name = dyn_window.name
-        unless dyn_window_name.empty?
-          act_name = replace_ems_special_characters(dyn_window_name.get) + '_Actuator' + @@actuator_count.to_s
-          @@actuator_count = @@actuator_count + 1
-          window_act.setName(act_name)
-          actuator_names << act_name
-        end
+        act_name = replace_ems_special_characters(dyn_window.nameString) + 'Actuator' + @@actuator_count.to_s
+        @@actuator_count = @@actuator_count + 1
+        window_act.setName(act_name)
+        actuator_names << act_name
       end
 
       # create the EMS Program to accout for each state according to the control logic
       ems_program = OpenStudio::Model::EnergyManagementSystemProgram.new(openstudio_model)
-      prog_name = replace_ems_special_characters(@hash[:identifier]) + '_StateChange' + @@program_count.to_s
+      prog_name = replace_ems_special_characters(@hash[:identifier]) + 'StateChange' + @@program_count.to_s
       @@program_count = @@program_count + 1
       ems_program.setName(prog_name)
 
@@ -143,12 +140,9 @@ module Honeybee
         # create the construction index variable
         constr_i = OpenStudio::Model::EnergyManagementSystemConstructionIndexVariable.new(
           openstudio_model, construction)
-        constr_name = construction.name
-        unless constr_name.empty?
-          constr_i_name = replace_ems_special_characters(constr_name.get) + '_State' + @@state_count.to_s
-          @@state_count = @@state_count + 1
-          constr_i.setName(constr_i_name)
-        end
+        constr_i_name = replace_ems_special_characters(construction.nameString) + 'State' + @@state_count.to_s
+        @@state_count = @@state_count + 1
+        constr_i.setName(constr_i_name)
 
         # loop through the actuators and set the appropriate window state
         actuator_names.each do |act_name|

--- a/lib/to_openstudio/ventcool/control.rb
+++ b/lib/to_openstudio/ventcool/control.rb
@@ -85,7 +85,7 @@ module Honeybee
         in_var.setKeyValue(os_zone_name)
       end
       in_air_temp = OpenStudio::Model::EnergyManagementSystemSensor.new(openstudio_model, in_var)
-      in_sensor_name = replace_ems_special_characters(os_zone_name) + '_Sensor' + @@sensor_count.to_s
+      in_sensor_name = replace_ems_special_characters(os_zone_name) + 'Sensor' + @@sensor_count.to_s
       @@sensor_count = @@sensor_count + 1
       in_air_temp.setName(in_sensor_name)
 
@@ -97,7 +97,7 @@ module Honeybee
           sch_var.setReportingFrequency('Timestep')
           sch_var.setKeyValue(@hash[:schedule])
           sch_sens = OpenStudio::Model::EnergyManagementSystemSensor.new(openstudio_model, sch_var)
-          sch_sensor_name = replace_ems_special_characters(os_zone_name) + '_Sensor' + @@sensor_count.to_s
+          sch_sensor_name = replace_ems_special_characters(os_zone_name) + 'Sensor' + @@sensor_count.to_s
           @@sensor_count = @@sensor_count + 1
           sch_sens.setName(sch_sensor_name)
         end
@@ -108,14 +108,11 @@ module Honeybee
       vent_opening_surfaces.each do |vent_srf|
         window_act = OpenStudio::Model::EnergyManagementSystemActuator.new(
             vent_srf, 'AirFlow Network Window/Door Opening', 'Venting Opening Factor')
-        vent_srf_name = vent_srf.name
-        unless vent_srf_name.empty?
-          act_name = replace_ems_special_characters(vent_srf_name.get) + \
-            '_OpenFactor' + @@actuator_count.to_s
-            @@actuator_count = @@actuator_count + 1
-          window_act.setName(act_name)
-          actuator_names << act_name
-        end
+        act_name = replace_ems_special_characters(vent_srf.nameString) + \
+          'OpenFactor' + @@actuator_count.to_s
+          @@actuator_count = @@actuator_count + 1
+        window_act.setName(act_name)
+        actuator_names << act_name
       end
 
       # create the first line of the EMS Program to open each window according to the control logic
@@ -158,7 +155,7 @@ module Honeybee
 
       # initialize the program and add the complete logic
       ems_program = OpenStudio::Model::EnergyManagementSystemProgram.new(openstudio_model)
-      prog_name = replace_ems_special_characters(os_zone_name) + '_WindowOpening' + @@program_count.to_s
+      prog_name = replace_ems_special_characters(os_zone_name) + 'WindowOpening' + @@program_count.to_s
       @@program_count = @@program_count + 1
       ems_program.setName(prog_name)
       ems_program.addLine(complete_logic)


### PR DESCRIPTION
It seems that some people will give IDs to objects that contain no valid EMS characters and we should be prepared to handle these cases.