### PR TITLE
fix(model_object): Put back encoding options with ** operator

### DIFF
--- a/lib/honeybee/model_object.rb
+++ b/lib/honeybee/model_object.rb
@@ -36,6 +36,13 @@ module Honeybee
 
     attr_reader :errors, :warnings
 
+    @@encoding_options = {
+      :invalid           => :replace,  # Replace invalid byte sequences
+      :undef             => :replace,  # Replace anything not defined in ASCII
+      :replace           => '',        # Use a blank for those replacements
+      :universal_newline => true       # Always break lines with \n
+    }
+
     def method_missing(sym, *args)
       name = sym.to_s
       aname = name.sub('=', '')
@@ -100,12 +107,12 @@ module Honeybee
 
     # remove illegal characters in identifier
     def self.clean_name(str)
-      ascii = str.encode(Encoding.find('ASCII'))
+      ascii = str.encode(Encoding.find('ASCII'), **@@encoding_options)
     end
 
     # remove illegal characters in identifier
     def self.clean_identifier(str)
-      encode_str = str.encode(Encoding.find('ASCII'))
+      encode_str = str.encode(Encoding.find('ASCII'), **@@encoding_options)
       encode_str.gsub(/[^.A-Za-z0-9_-]/, '_').gsub(' ', '_')
     end
 


### PR DESCRIPTION
It seems it was wrong of me to delete this before since the encoding options are necessary for certain characters. However,, I need to use the ** operator in order to not get a deprecation warning.