### PR TITLE
fix(geometry): Remove the automatic reorderULC for all vertices

### DIFF
--- a/lib/to_openstudio/geometry/aperture.rb
+++ b/lib/to_openstudio/geometry/aperture.rb
@@ -48,14 +48,13 @@ module Honeybee
       @hash[:geometry][:boundary].each do |vertex|
         os_vertices << OpenStudio::Point3d.new(vertex[0], vertex[1], vertex[2])
       end
-      reordered_vertices = OpenStudio.reorderULC(os_vertices)
 
       # triangulate subsurface if neccesary
       triangulated = false
       final_vertices_list = []
       matching_os_subsurfaces = []
       matching_os_subsurface_indices = []
-      if reordered_vertices.size > 4
+      if os_vertices.size > 4
 
         # if this apeture has a matched apeture, see if the other one has already been created
         # the matched apeture should have been converted to multiple subsurfaces
@@ -75,9 +74,9 @@ module Honeybee
         if final_vertices_list.empty?
 
           # transform to face coordinates
-          t = OpenStudio::Transformation::alignFace(reordered_vertices)
+          t = OpenStudio::Transformation::alignFace(os_vertices)
           tInv = t.inverse
-          face_vertices = OpenStudio::reverse(tInv*reordered_vertices)
+          face_vertices = OpenStudio::reverse(tInv*os_vertices)
 
           # no holes in the subsurface
           holes = OpenStudio::Point3dVectorVector.new
@@ -85,7 +84,7 @@ module Honeybee
           # triangulate surface
           triangles = OpenStudio::computeTriangulation(face_vertices, holes)
           if triangles.empty?
-            raise "Failed to triangulate aperture #{@hash[:identifier]} with #{reordered_vertices.size} vertices"
+            raise "Failed to triangulate aperture #{@hash[:identifier]} with #{os_vertices.size} vertices"
           end
 
           # create new list of surfaces
@@ -98,13 +97,13 @@ module Honeybee
         end
 
       else
-        # reordered_vertices are good as is
-        final_vertices_list << reordered_vertices
+        # os_vertices are good as is
+        final_vertices_list << os_vertices
       end
 
       result = []
-      final_vertices_list.each_with_index do |reordered_vertices, index|
-        os_subsurface = OpenStudio::Model::SubSurface.new(reordered_vertices, openstudio_model)
+      final_vertices_list.each_with_index do |os_vertices, index|
+        os_subsurface = OpenStudio::Model::SubSurface.new(os_vertices, openstudio_model)
 
         if !matching_os_subsurfaces.empty?
           os_subsurface.setName(@hash[:identifier] + "..#{matching_os_subsurface_indices[index]}")
@@ -174,9 +173,8 @@ module Honeybee
       hb_verts.each do |vertex|
         os_vertices << OpenStudio::Point3d.new(vertex[0], vertex[1], vertex[2])
       end
-      reordered_vertices = OpenStudio.reorderULC(os_vertices)
 
-      os_shading_surface = OpenStudio::Model::ShadingSurface.new(reordered_vertices, openstudio_model)
+      os_shading_surface = OpenStudio::Model::ShadingSurface.new(os_vertices, openstudio_model)
       os_shading_surface.setName(@hash[:identifier])
       unless @hash[:display_name].nil?
         os_shading_surface.setDisplayName(@hash[:display_name])

--- a/lib/to_openstudio/geometry/face.rb
+++ b/lib/to_openstudio/geometry/face.rb
@@ -55,10 +55,9 @@ module Honeybee
       hb_verts.each do |vertex|
         os_vertices << OpenStudio::Point3d.new(vertex[0], vertex[1], vertex[2])
       end
-      reordered_vertices = OpenStudio.reorderULC(os_vertices)
 
       # create the openstudio surface and assign the type
-      os_surface = OpenStudio::Model::Surface.new(reordered_vertices, openstudio_model)
+      os_surface = OpenStudio::Model::Surface.new(os_vertices, openstudio_model)
       os_surface.setName(@hash[:identifier])
       unless @hash[:display_name].nil?
         os_surface.setDisplayName(@hash[:display_name])
@@ -198,9 +197,8 @@ module Honeybee
       hb_verts.each do |vertex|
         os_vertices << OpenStudio::Point3d.new(vertex[0], vertex[1], vertex[2])
       end
-      reordered_vertices = OpenStudio.reorderULC(os_vertices)
 
-      os_shading_surface = OpenStudio::Model::ShadingSurface.new(reordered_vertices, openstudio_model)
+      os_shading_surface = OpenStudio::Model::ShadingSurface.new(os_vertices, openstudio_model)
       os_shading_surface.setName(@hash[:identifier])
       unless @hash[:display_name].nil?
         os_shading_surface.setDisplayName(@hash[:display_name])

--- a/lib/to_openstudio/geometry/shade.rb
+++ b/lib/to_openstudio/geometry/shade.rb
@@ -55,9 +55,8 @@ module Honeybee
       hb_verts.each do |vertex|
         os_vertices << OpenStudio::Point3d.new(vertex[0], vertex[1], vertex[2])
       end
-      reordered_vertices = OpenStudio.reorderULC(os_vertices)
 
-      os_shading_surface = OpenStudio::Model::ShadingSurface.new(reordered_vertices, openstudio_model)
+      os_shading_surface = OpenStudio::Model::ShadingSurface.new(os_vertices, openstudio_model)
       os_shading_surface.setName(@hash[:identifier])
       unless @hash[:display_name].nil?
         os_shading_surface.setDisplayName(@hash[:display_name])


### PR DESCRIPTION
After delving a little into the OpenStudio source code, I have realized that the methods we have in ladybug_geometry to obtain the upper-left vertex are a bit better than OpenStudio's. This is particularly so in cases where we have to decide whether the "upper" or the "left" is of a higher importance for a given geometry.

So I now just ensure that the HBJSON that the gem gets will always have vertices fed to it in a manner that is upper-left -counter-clockwise using our methods in ladybug_geometry. And I am removing the methods here that would replace these vertices with a potentially less-accurate version.