### PR TITLE
fix(template): Ensure we find a zone that's connected to the air loop

### DIFF
--- a/lib/to_openstudio/hvac/template.rb
+++ b/lib/to_openstudio/hvac/template.rb
@@ -85,7 +85,11 @@ module Honeybee
       air_loops = openstudio_model.getAirLoopHVACs
       unless air_loops.length == $air_loop_count  # check if any new loops were added
         $air_loop_count = air_loops.length
-        os_air_terminal = zones[0].airLoopHVACTerminal
+        os_air_terminal = []
+        zones.each do |zon|
+          os_air_terminal = zon.airLoopHVACTerminal
+          break if !os_air_terminal.empty?
+        end
         unless os_air_terminal.empty?
           os_air_terminal = os_air_terminal.get
           os_air_loop_opt = os_air_terminal.airLoopHVAC


### PR DESCRIPTION
It seems that the standards gem is pretty smart and it will not add zones to the DOAS if they have no outdoor air ventilation requirement. So we have to loop through the zones assigned to a HVAC system until we find one that is connected to the air loop.