### PR TITLE
fix(typelimit): Implement workaround for odd schedule unit types

### DIFF
--- a/lib/from_openstudio/schedule/type_limit.rb
+++ b/lib/from_openstudio/schedule/type_limit.rb
@@ -35,6 +35,23 @@ require 'to_openstudio/model_object'
 module Honeybee
   class ScheduleTypeLimit < ModelObject
 
+    @@unit_types = [
+      'Dimensionless',
+      'Temperature',
+      'DeltaTemperature',
+      'PrecipitationRate',
+      'Angle',
+      'ConvectionCoefficient',
+      'ActivityLevel',
+      'Velocity',
+      'Capacity',
+      'Power',
+      'Availability',
+      'Percent',
+      'Control',
+      'Mode'
+    ]
+
     def self.from_schedule_type_limit(schedule_type_limit)
       # create an empty hash
       hash = {}
@@ -71,7 +88,9 @@ module Honeybee
       elsif unit_type == 'Controlmode'
         unit_type = 'Control'
       end
-      hash[:unit_type] = unit_type
+      if @@unit_types.include? unit_type
+        hash[:unit_type] = unit_type
+      end
 
       hash
     end


### PR DESCRIPTION
It seems that the OpenStudio IDF importer keeps producing ScheduleTypeLimits with unit types that don't appear in the EnergyPlus IDD so I'm just going to ignore the unit type when it isn't identified as one of the acceptable ones.