### PR TITLE
feat(ServiceHotWater): Adds Service Hot water reverse translator

### DIFF
--- a/lib/from_openstudio.rb
+++ b/lib/from_openstudio.rb
@@ -80,6 +80,7 @@ require 'from_openstudio/load/infiltration'
 require 'from_openstudio/load/ventilation'
 require 'from_openstudio/load/daylight'
 require 'from_openstudio/load/process'
+require 'from_openstudio/load/service_hot_water'
 
 # extend the program type objects
 require 'from_openstudio/program_type'

--- a/lib/from_openstudio/geometry/room.rb
+++ b/lib/from_openstudio/geometry/room.rb
@@ -173,6 +173,11 @@ module Honeybee
       unless space.daylightingControls.empty?
         hash[:daylighting_control] = Honeybee::DaylightingControl.from_load(space.daylightingControls[0])
       end
+      unless space.waterUseEquipment.empty?
+        # Get floor area 
+        floor_area = space.floorArea
+        hash[:service_hot_water] = Honeybee::ServiceHotWaterAbridged.from_load(space.waterUseEquipment[0], floor_area)
+      end
       thermal_zone = space.thermalZone
       unless thermal_zone.empty?
         thermal_zone = space.thermalZone.get

--- a/lib/from_openstudio/load/service_hot_water.rb
+++ b/lib/from_openstudio/load/service_hot_water.rb
@@ -1,0 +1,60 @@
+# *******************************************************************************
+# Honeybee OpenStudio Gem, Copyright (c) 2020, Alliance for Sustainable
+# Energy, LLC, Ladybug Tools LLC and other contributors. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# (1) Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# (2) Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# (3) Neither the name of the copyright holder nor the names of any contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission from the respective party.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER(S) AND ANY CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER(S), ANY CONTRIBUTORS, THE
+# UNITED STATES GOVERNMENT, OR THE UNITED STATES DEPARTMENT OF ENERGY, NOR ANY OF
+# THEIR EMPLOYEES, BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+# OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# *******************************************************************************
+
+require 'honeybee/load/service_hot_water'
+require 'to_openstudio/model_object'
+
+module Honeybee
+    class ServiceHotWaterAbridged
+
+        def self.from_load(load, floor_area)
+            # create an empty hash
+            hash = {}
+            hash[:type] = 'ServiceHotWaterAbridged'
+            # set hash values from OpenStudio Object
+            hash[:identifier] = clean_name(load.nameString)
+            load_def = load.WaterUseEquipmentDefinition
+            # units of peak flow rate are m3/s
+            peak_flow = load_def.peakFlowRate
+            # unit for flow per area is L/h-m2 (m3/s = 3600000 L/h)
+            hash[:flow_per_area] = (peak_flow * 3600000)/floor_area
+            unless load_def.flowRateFractionSchedule.empty?
+                sch = load_def.flowRateFractionSchedule
+                # Translate only Scheudle Ruleset and Schedule Fixed Interval
+                if sch.to_ScheduleRuleset.is_initialized or sch.to_ScheduleFixedInterval.is_initialized
+                    hash[:schedule] = load_def.flowRateFractionSchedule.get.nameString
+                end
+            end
+
+            hash
+        end
+    end #ServiceHotWaterAbridged
+end #Honeybee


### PR DESCRIPTION
Fixes #264 

- Adds reverse translator for Service Hot Water
- At the room level, creates new reverse translator object if OS Water Use Equipment object is present