### PR TITLE
fix(aperture): Expose sub-face triangulation as a global option

### DIFF
--- a/lib/honeybee/model.rb
+++ b/lib/honeybee/model.rb
@@ -52,6 +52,7 @@ module Honeybee
       @@extension ||= Extension.new
       @@schema ||= @@extension.schema
       @@standards ||= @@extension.standards
+      $triangulate_sub_faces = false
       $simple_window_cons = false
 
       @hash = hash

--- a/lib/to_openstudio/geometry/aperture.rb
+++ b/lib/to_openstudio/geometry/aperture.rb
@@ -54,7 +54,7 @@ module Honeybee
       final_vertices_list = []
       matching_os_subsurfaces = []
       matching_os_subsurface_indices = []
-      if os_vertices.size > 4
+      if $triangulate_sub_faces && os_vertices.size > 4
 
         # if this apeture has a matched apeture, see if the other one has already been created
         # the matched apeture should have been converted to multiple subsurfaces

--- a/lib/to_openstudio/geometry/door.rb
+++ b/lib/to_openstudio/geometry/door.rb
@@ -54,7 +54,7 @@ module Honeybee
       final_vertices_list = []
       matching_os_subsurfaces = []
       matching_os_subsurface_indices = []
-      if os_vertices.size > 4
+      if $triangulate_sub_faces && os_vertices.size > 4
 
         # if this door has a matched door, see if the other one has already been created
         # the matched door should have been converted to multiple subsurfaces

--- a/spec/tests/honeybee_model_spec.rb
+++ b/spec/tests/honeybee_model_spec.rb
@@ -304,11 +304,13 @@ RSpec.describe Honeybee do
     openstudio_model.getYearDescription.setCalendarYear(2017)
     file = File.join(File.dirname(__FILE__), '../samples/model/model_5vertex_sub_faces.hbjson')
     honeybee_obj_1 = Honeybee::Model.read_from_disk(file)
+    $triangulate_sub_faces = true
     object1 = honeybee_obj_1.to_openstudio_model(openstudio_model, log_report=false)
     expect(object1).not_to be nil
 
     openstudio_surfaces = openstudio_model.getSubSurfaces
     expect(openstudio_surfaces.size).to be >= 4
+    $triangulate_sub_faces = false
   end
 
   it 'can triangulate 5vertex sub faces with interior boundary conditions' do
@@ -316,6 +318,7 @@ RSpec.describe Honeybee do
     openstudio_model.getYearDescription.setCalendarYear(2017)
     file = File.join(File.dirname(__FILE__), '../samples/model/model_5vertex_sub_faces_interior.hbjson')
     honeybee_obj_1 = Honeybee::Model.read_from_disk(file)
+    $triangulate_sub_faces = true
     object1 = honeybee_obj_1.to_openstudio_model(openstudio_model, log_report=false)
     expect(object1).not_to be nil
 
@@ -346,6 +349,7 @@ RSpec.describe Honeybee do
       end
 
       expect(num_surfaces_with_subsurfaces).to eq 1
+      $triangulate_sub_faces = false
     end
   end
 


### PR DESCRIPTION
It seems there are some times when we really want to turn this off (gbXML export in particular). So I'm exposing it as a global variable, which we might expose as an option on certain measures.