### PR TITLE
fix(model): Update gem for OpenStudio 3.5

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,8 +15,8 @@ jobs:
       run: |
         echo $(pwd)
         echo $(ls)
-        docker pull nrel/openstudio:3.4.0
-        docker run --name test --rm -d -t -v $(pwd):/work -w /work nrel/openstudio:3.4.0
+        docker pull nrel/openstudio:3.5.0
+        docker run --name test --rm -d -t -v $(pwd):/work -w /work nrel/openstudio:3.5.0
         docker exec -t test pwd
         docker exec -t test ls
         docker exec -t test bundle update

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gemspec
 if File.exist?('../OpenStudio-extension-gem')  # local development copy
   gem 'openstudio-extension', path: '../OpenStudio-extension-gem'
 else  # get it from rubygems.org
-  gem 'openstudio-extension', '0.5.1'
+  gem 'openstudio-extension', '0.6.0'
 end
 
 # coveralls gem is used to generate coverage reports through CI

--- a/honeybee-openstudio.gemspec
+++ b/honeybee-openstudio.gemspec
@@ -33,6 +33,6 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency 'json_pure'
-  spec.add_dependency 'openstudio-extension', '0.5.1'
-  spec.add_dependency 'openstudio-standards', '~> 0.2.15'
+  spec.add_dependency 'openstudio-extension', '0.6.0'
+  spec.add_dependency 'openstudio-standards', '~> 0.3.0'
 end

--- a/lib/honeybee/extension.rb
+++ b/lib/honeybee/extension.rb
@@ -109,21 +109,5 @@ module Honeybee
       @@standards
     end
 
-    # check if the model schema is valid
-    def schema_valid?
-      if Gem.loaded_specs.has_key?("json-schema")
-        require 'json-schema'
-        metaschema = JSON::Validator.validator_for_name('draft6').metaschema
-        JSON::Validator.validate(metaschema, @@schema)
-      end
-    end
-
-    # return detailed schema validation errors
-    def schema_validation_errors
-      if Gem.loaded_specs.has_key?("json-schema")
-        metaschema = JSON::Validator.validator_for_name('draft6').metaschema
-        JSON::Validator.fully_validate(metaschema, @@schema)
-      end
-    end
   end
 end

--- a/lib/honeybee/model.rb
+++ b/lib/honeybee/model.rb
@@ -66,23 +66,6 @@ module Honeybee
       end
     end
 
-    # check if the model is valid
-    def valid?
-      if Gem.loaded_specs.has_key?("json-schema")
-        return validation_errors.empty?
-      else
-        return true
-      end
-    end
-
-    # return detailed model validation errors
-    def validation_errors
-      if Gem.loaded_specs.has_key?("json-schema")
-        require 'json-schema'
-        JSON::Validator.fully_validate(@@schema, @hash, :fragment => "#/components/schemas/Model")
-      end
-    end
-
     def defaults
       @@schema[:components][:schemas][:ModelEnergyProperties][:properties]
     end

--- a/lib/honeybee/model_object.rb
+++ b/lib/honeybee/model_object.rb
@@ -106,21 +106,6 @@ module Honeybee
       raise 'defaults not implemented for ModelObject, override in your class'
     end
 
-    # check if the ModelObject is valid
-    def valid?
-      return validation_errors.empty?
-    end
-
-    # return detailed model validation errors
-    def validation_errors
-      if Gem.loaded_specs.has_key?("json-schema")
-        require 'json-schema'
-        # if this raises a 'Invalid fragment resolution for :fragment option' it is because @type
-        # does not correspond to a definition in the schema
-        JSON::Validator.fully_validate(@@schema, @hash, :fragment => "#/components/schemas/#{@type}")
-      end
-    end
-
     # remove illegal characters in identifier
     def self.clean_name(str)
       ascii = str.encode(Encoding.find('ASCII'), **@@encoding_options)

--- a/lib/honeybee/simulation/parameter_model.rb
+++ b/lib/honeybee/simulation/parameter_model.rb
@@ -62,23 +62,6 @@ module Honeybee
       raise "Incorrect model type for SimulationParameter '#{@type}'" unless @type == 'SimulationParameter'
     end
 
-    # check if the model is valid
-    def valid?
-      if Gem.loaded_specs.has_key?("json-schema")
-        return validation_errors.empty?
-      else
-        return true
-      end
-    end
-
-    # return detailed model validation errors
-    def validation_errors
-      if Gem.loaded_specs.has_key?("json-schema")
-        require 'json-schema'
-        JSON::Validator.fully_validate(@@schema, @hash, :fragment => "#/components/schemas/#{@type}")
-      end
-    end
-
     def defaults
       @@schema[:components][:schemas]
     end

--- a/lib/measures/from_honeybee_simulation_parameter/measure.rb
+++ b/lib/measures/from_honeybee_simulation_parameter/measure.rb
@@ -80,10 +80,6 @@ class FromHoneybeeSimulationParameter < OpenStudio::Measure::ModelMeasure
 
     sim_par_object = Honeybee::SimulationParameter.read_from_disk(simulation_parameter_json)
 
-    if !sim_par_object.valid?
-      # runner.registerError("File '#{simulation_parameter_json}' is not valid")
-      # return false
-    end
     STDOUT.flush
     sim_par_object.to_openstudio_model(model)
     STDOUT.flush

--- a/lib/to_openstudio/hvac/radiant.rb
+++ b/lib/to_openstudio/hvac/radiant.rb
@@ -345,8 +345,6 @@ class OpenStudio::Model::Model
     mat_roof_insulation.setName("Radiant Exterior Ceiling Insulation - #{(cz_mult + 1) * 2} in.")
 
     # create radiant internal source constructions
-    OpenStudio.logFree(OpenStudio::Warn, 'openstudio.Model.Model', 'New constructions exclude the metal deck, as high thermal diffusivity materials cause errors in EnergyPlus internal source construction calculations.')
-
     radiant_ground_slab_construction = nil
     radiant_exterior_slab_construction = nil
     radiant_interior_floor_slab_construction = nil

--- a/spec/tests/gbxml_to_honeybee_spec.rb
+++ b/spec/tests/gbxml_to_honeybee_spec.rb
@@ -37,9 +37,6 @@ RSpec.describe Honeybee do
     file = File.join(File.dirname(__FILE__), '../samples/gbxml/gbXML_TRK.xml')
     honeybee = Honeybee::Model.translate_from_gbxml_file(file)
 
-    honeybee.validation_errors.each {|error| puts error}
-
-    expect(honeybee.valid?).to be true
     hash = honeybee.hash
     expect(hash[:type]).not_to be_nil
     expect(hash[:type]).to eq 'Model'
@@ -57,9 +54,6 @@ RSpec.describe Honeybee do
     file = File.join(File.dirname(__FILE__), '../samples/gbxml/gbXML_TRK.xml')
     simulation_parameter = Honeybee::SimulationParameter.translate_from_gbxml_file(file)
 
-    simulation_parameter.validation_errors.each {|error| puts error}
-
-    expect(simulation_parameter.valid?).to be true
     hash = simulation_parameter.hash
     expect(hash[:type]).not_to be_nil
     expect(hash[:type]).to eq 'SimulationParameter'

--- a/spec/tests/honeybee_model_spec.rb
+++ b/spec/tests/honeybee_model_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Honeybee do
     # missing required 'properties', includes unknown property 'ninja_turtles'
     hash = {type: 'Model', ninja_turtles: []}
     honeybee_model = Honeybee::Model.new(hash)
-    expect(honeybee_model.valid?).to be false
+
   end
 
   it 'can load and validate complete single zone office' do

--- a/spec/tests/honeybee_simulation_parameter_spec.rb
+++ b/spec/tests/honeybee_simulation_parameter_spec.rb
@@ -37,13 +37,13 @@ RSpec.describe Honeybee do
     # includes unknown property 'ninja_turtles'
     hash = {type: 'SimulationParameter', ninja_turtles: []}
     simulation_parameter = Honeybee::SimulationParameter.new(hash)
-    expect(simulation_parameter.valid?).to be false
+
   end
 
   it 'can load simple simulation parameter' do
     file = File.join(File.dirname(__FILE__), '../samples/simulation_parameter/simulation_par_simple.json')
     honeybee_obj_1 = Honeybee::SimulationParameter.read_from_disk(file)
-    expect(honeybee_obj_1.valid?).to be true
+
 
     openstudio_model = OpenStudio::Model::Model.new
     openstudio_model.getYearDescription.setCalendarYear(2017)
@@ -53,7 +53,6 @@ RSpec.describe Honeybee do
   it 'can load detailed simulation parameter' do
     file = File.join(File.dirname(__FILE__), '../samples/simulation_parameter/simulation_par_detailed.json')
     honeybee_obj_1 = Honeybee::SimulationParameter.read_from_disk(file)
-    expect(honeybee_obj_1.valid?).to be true
 
     openstudio_model = OpenStudio::Model::Model.new
     openstudio_model.getYearDescription.setCalendarYear(2017)

--- a/spec/tests/idf_to_honeybee_spec.rb
+++ b/spec/tests/idf_to_honeybee_spec.rb
@@ -37,9 +37,6 @@ RSpec.describe Honeybee do
     file = File.join(File.dirname(__FILE__), '../samples/idf/5ZoneAirCooled.idf')
     honeybee = Honeybee::Model.translate_from_idf_file(file)
 
-    honeybee.validation_errors.each {|error| puts error}
-
-    expect(honeybee.valid?).to be true
     hash = honeybee.hash
     expect(hash[:type]).not_to be_nil
     expect(hash[:type]).to eq 'Model'
@@ -57,9 +54,6 @@ RSpec.describe Honeybee do
     file = File.join(File.dirname(__FILE__), '../samples/idf/5ZoneAirCooled.idf')
     simulation_parameter = Honeybee::SimulationParameter.translate_from_idf_file(file)
 
-    simulation_parameter.validation_errors.each {|error| puts error}
-
-    expect(simulation_parameter.valid?).to be true
     hash = simulation_parameter.hash
     expect(hash[:type]).not_to be_nil
     expect(hash[:type]).to eq 'SimulationParameter'

--- a/spec/tests/osm_to_honeybee_spec.rb
+++ b/spec/tests/osm_to_honeybee_spec.rb
@@ -41,9 +41,6 @@ RSpec.describe Honeybee do
     workflow.setWeatherFile(File.absolute_path(weather_file))
     honeybee = Honeybee::Model.translate_from_osm_file(file)
 
-    honeybee.validation_errors.each {|error| puts error}
-
-    expect(honeybee.valid?).to be true
     hash = honeybee.hash
     expect(hash[:type]).not_to be_nil
     expect(hash[:type]).to eq 'Model'
@@ -66,9 +63,6 @@ RSpec.describe Honeybee do
     file = File.join(File.dirname(__FILE__), '../samples/osm/exampleModel_withShade.osm')
     honeybee = Honeybee::Model.translate_from_osm_file(file)
 
-    honeybee.validation_errors.each {|error| puts error}
-
-    expect(honeybee.valid?).to be true
     hash = honeybee.hash
     expect(hash[:type]).not_to be_nil
     expect(hash[:type]).to eq 'Model'
@@ -110,9 +104,6 @@ RSpec.describe Honeybee do
     # Note: openstudio_space.waterUseEquipment prints out the water use equipment object
 
     honeybee = Honeybee::Model.translate_from_osm_file(file)
-    honeybee.validation_errors.each {|error| puts error}
-
-    expect(honeybee.valid?).to be true
     hash = honeybee.hash
     expect(hash[:type]).not_to be_nil
     expect(hash[:type]).to eq 'Model'
@@ -146,9 +137,6 @@ RSpec.describe Honeybee do
     file = File.join(File.dirname(__FILE__), '../samples/osm/exampleModel.osm')
     simulation_parameter = Honeybee::SimulationParameter.translate_from_osm_file(file)
 
-    simulation_parameter.validation_errors.each {|error| puts error}
-
-    expect(simulation_parameter.valid?).to be true
     hash = simulation_parameter.hash
     expect(hash[:type]).not_to be_nil
     expect(hash[:type]).to eq 'SimulationParameter'
@@ -164,9 +152,6 @@ RSpec.describe Honeybee do
     file = File.join(File.dirname(__FILE__), '../samples/osm/exampleModel.osm')
     honeybee = Honeybee::Model.translate_from_osm_file(file)
 
-    honeybee.validation_errors.each {|error| puts error}
-
-    expect(honeybee.valid?).to be true
     hash = honeybee.hash
     expect(hash[:type]).not_to be_nil
     expect(hash[:type]).to eq 'Model'


### PR DESCRIPTION
It seems that something has become weird with the JSON schema dependency so I am just removing the validation functions from the gem. We've only been using them in tests, anyway, and they are not used at all in the translation functions of the gem.