### PR TITLE
style(sdd): Fix the formatting of reverse translator

### DIFF
--- a/lib/from_openstudio/model.rb
+++ b/lib/from_openstudio/model.rb
@@ -112,8 +112,8 @@ module Honeybee
     end
 
     # Create Honeybee Model JSON from SDD file
-    def translate_from_sdd_file(file)
-      translator = OpenStudio::SDD::ReverseTranslator.new
+    def self.translate_from_sdd_file(file)
+      translator = OpenStudio::SDD::SddReverseTranslator.new
       openstudio_model = translator.loadModel(file)
       raise "Cannot load SDD file at '#{}'" if openstudio_model.empty?
       self.translate_from_openstudio(openstudio_model.get)


### PR DESCRIPTION
This seems a big inconsequential given that the reverse translator is not currently supported by OpenStudio SDK. But I'm doing it for good practice.