### PR TITLE
fix(simulation): Take an iron-fisted approach with Simulation Control

### DIFF
--- a/lib/to_openstudio/simulation/parameter_model.rb
+++ b/lib/to_openstudio/simulation/parameter_model.rb
@@ -157,10 +157,12 @@ module Honeybee
         end
         # set any design days
         if @hash[:sizing_parameter][:design_days]
-          @hash[:sizing_parameter][:design_days].each do |des_day|
-            des_day_object = DesignDay.new(des_day)
-            os_des_day = des_day_object.to_openstudio(@openstudio_model)
-            db_temps << des_day[:dry_bulb_condition][:dry_bulb_max]
+          if @hash[:simulation_control][:do_zone_sizing].nil? || @hash[:simulation_control][:do_zone_sizing] == true
+            @hash[:sizing_parameter][:design_days].each do |des_day|
+              des_day_object = DesignDay.new(des_day)
+              os_des_day = des_day_object.to_openstudio(@openstudio_model)
+              db_temps << des_day[:dry_bulb_condition][:dry_bulb_max]
+            end
           end
         end
       end


### PR DESCRIPTION
It seems that, even when you tell the OSM to not perform the sizing calculation with simulation control, the OpenStudio SDK does not translate this into the IDF. To get around this, I'm taking an iron-fisted approach where I just don't write the design days into the OSM/IDF when simulation control says to not perform zone sizing.

This produces the desired behavior, though I should note that the simulation is only successful when the model is unconditioned or the only HVAC is IdealAir with NoLimit sizing and no exonomizer.